### PR TITLE
[Fix] 유저목록 모달창 수정 #18

### DIFF
--- a/src/assets/close.svg
+++ b/src/assets/close.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.00098 5L19 18.9991" stroke="#292D32" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.99996 18.9991L18.999 5" stroke="#292D32" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/rootlayout/Sidebar.tsx
+++ b/src/components/rootlayout/Sidebar.tsx
@@ -1,8 +1,22 @@
+import { useState } from "react";
 import ChannelList from "../ChannelList";
+import UserListModal from "../userlistModal/UserListModal";
 
 export default function Sidebar() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleBackClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    setIsOpen(false);
+  };
+
   return (
-    <div className="flex flex-col items-center w-[350px] py-5 gap-8 text-[#1D1D1D] bg-[#FEFEFE] border-r border-gray-200/50">
+    <div
+      className={`flex flex-col items-center w-[350px] 
+      py-5 gap-8 text-[#1D1D1D] bg-[#FEFEFE] border-r
+      border-gray-200/50 relative ${isOpen ? "before:modal-back" : ""}`}
+      onClick={(e) => handleBackClick(e)}
+    >
       <button className="w-10 self-end mr-2">
         <img src="/src/assets/double-left.svg" alt="" />
       </button>
@@ -56,9 +70,16 @@ export default function Sidebar() {
           </ul>
         </div>
         {/* 유저목록 버튼 */}
-        <button className="self-center w-[243px] h-[50px] bg-[#3B6CB4] rounded-[20px] text-xl text-white font-bold">
+        <button
+          className="self-center w-[243px] h-[50px] bg-[#3B6CB4] rounded-[20px] text-xl text-white font-bold relative"
+          onClick={(e) => {
+            e.stopPropagation();
+            setIsOpen((prev) => !prev);
+          }}
+        >
           유저 목록
         </button>
+        {isOpen && <UserListModal />}
       </div>
     </div>
   );

--- a/src/components/rootlayout/Sidebar.tsx
+++ b/src/components/rootlayout/Sidebar.tsx
@@ -79,7 +79,7 @@ export default function Sidebar() {
         >
           유저 목록
         </button>
-        {isOpen && <UserListModal />}
+        {isOpen && <UserListModal handleBackClick={handleBackClick} />}
       </div>
     </div>
   );

--- a/src/components/userlistModal/UserListModal.tsx
+++ b/src/components/userlistModal/UserListModal.tsx
@@ -1,19 +1,32 @@
 import UserBox from "./UserBox";
+import closeIcon from "../../assets/close.svg";
 import searchIcon from "../../assets/searchIcon.svg";
-export default function UserListModal() {
+
+interface UserListModalType {
+  handleBackClick: (e: React.MouseEvent<HTMLDivElement>) => void;
+}
+
+export default function UserListModal({ handleBackClick }: UserListModalType) {
   return (
     <>
       <div
-        className="w-[380px] h-[600px]
-      bg-white rounded-[30px] absolute bottom-[3px] left-[300px]
+        className={`w-[380px] h-[600px]
+      bg-white rounded-[25px] absolute bottom-[3px] left-[300px]
       before:modal-before  scrollbar-none flex flex-col justify-start items-center
-      gap-10 py-8 z-30
-      "
+      gap-10 py-8 z-30`}
         onClick={(e) => {
           e.stopPropagation();
         }}
       >
-        <div className="relative flex justify-center items-center">
+        <div
+          className="w-[30px] h-[30px] absolute top-3 right-3 cursor-pointer hover:bg-[rgba(0,0,0,0.1)] rounded-[50%]
+          flex items-center justify-center
+        "
+          onClick={(e) => handleBackClick(e)}
+        >
+          <img src={closeIcon} alt="닫기 버튼" />
+        </div>
+        <div className="relative flex justify-center items-center mt-4">
           <input
             className="px-5 py-2 w-[320px] rounded-[25px] border border-[rgb(208, 208, 208)]
             outline-none

--- a/src/components/userlistModal/UserListModal.tsx
+++ b/src/components/userlistModal/UserListModal.tsx
@@ -5,10 +5,13 @@ export default function UserListModal() {
     <>
       <div
         className="w-[380px] h-[600px]
-      bg-white rounded-[50px] absolute bottom-3 left-[280px]
+      bg-white rounded-[30px] absolute bottom-[3px] left-[300px]
       before:modal-before  scrollbar-none flex flex-col justify-start items-center
-      gap-10 py-8
+      gap-10 py-8 z-30
       "
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
       >
         <div className="relative flex justify-center items-center">
           <input

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -22,7 +22,7 @@
   .modal-back {
     content: "";
     position: absolute;
-    background-color: rgba(0, 0, 0, 0.6);
+    background-color: rgba(0, 0, 0, 0.7);
     width: 100vw;
     height: 100vh;
     inset: 0;

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -10,11 +10,22 @@
     background-color: #fff;
     width: 30px;
     height: 30px;
-    bottom: 45px;
+    bottom: 30px;
     left: -12px;
     transform: rotate(45deg);
   }
   .scrollbar-none::-webkit-scrollbar {
     display: none;
+  }
+
+  /* 모달창 뒷 배경  */
+  .modal-back {
+    content: "";
+    position: absolute;
+    background-color: rgba(0, 0, 0, 0.6);
+    width: 100vw;
+    height: 100vh;
+    inset: 0;
+    z-index: 20;
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #18 

## 📝작업 내용
> 유저목록 모달창 사이드바 버튼으로  구현완료 했습니다. 모달창 상단에 닫기 버튼이 없어서 추가했고, 뒷 배경을 클릭하면 모달창 닫히게 했습니다.

## 📸 스크린샷

<img width="1242" alt="스크린샷 2024-12-07 오후 4 09 40" src="https://github.com/user-attachments/assets/b8d4895e-3aac-4db5-a59a-9bfe931676ff">

