### PR TITLE
[feat] 유저목록 프로필사진 구현완료_#54

### DIFF
--- a/src/components/userlistModal/UserBox.tsx
+++ b/src/components/userlistModal/UserBox.tsx
@@ -5,6 +5,7 @@ interface UserBoxPropsType {
   fullname: string;
   followers: string[];
   following: string[];
+  image?: string | null;
 }
 
 export default function UserBox({
@@ -12,12 +13,17 @@ export default function UserBox({
   followers,
   following,
   isOnline,
+  image,
 }: UserBoxPropsType) {
   return (
     <div className="w-[320px] h-[75px] bg-[#EFEFEF] flex items-center gap-3 pl-[20px] rounded-[10px] flex-shrink-0">
       {/* 유저 프로필, 현활 */}
       <div className="bg-white w-[48px] h-[48px] flex justify-center items-center rounded-[50%] shadow-inner cursor-pointer relative">
-        <img src={defaultUserImg} alt="사용자 프로필 사진" />
+        <img
+          src={image ? image : defaultUserImg}
+          alt="사용자 프로필 사진"
+          className="w-[35px] h-[35px] rounded-[50%]"
+        />
         {isOnline && (
           <div className="w-3 h-3 rounded-[50%] bg-[#1CE777] absolute bottom-0 right-0"></div>
         )}

--- a/src/components/userlistModal/UserListModal.tsx
+++ b/src/components/userlistModal/UserListModal.tsx
@@ -143,6 +143,7 @@ export default function UserListModal({ handleBackClick }: UserListModalType) {
                       followers={user.followers}
                       following={user.following}
                       isOnline={user.isOnline}
+                      image={user.image ? user.image : null}
                     />
                   )
               )

--- a/src/components/userlistModal/UserListModal.tsx
+++ b/src/components/userlistModal/UserListModal.tsx
@@ -126,6 +126,7 @@ export default function UserListModal({ handleBackClick }: UserListModalType) {
                   fullname={user.fullName}
                   followers={user.followers}
                   following={user.following}
+                  image={user.image ? user.image : null}
                 />
               ))
             ) : (

--- a/src/utils/getUserList.ts
+++ b/src/utils/getUserList.ts
@@ -17,6 +17,11 @@ export interface UserListType {
   email: string;
   createdAt: Date | string;
   updatedAt: Date | string;
+  __v: number;
+  image?: string;
+  imagePublicId?: string;
+  coverImage?: string;
+  coverImagePublicId?: string;
 }
 
 export const getUserList = async () => {

--- a/src/utils/searchUser.ts
+++ b/src/utils/searchUser.ts
@@ -17,6 +17,11 @@ export interface SearchUserType {
   email: string;
   createdAt: string;
   updatedAt: string;
+  __v: number;
+  image?: string;
+  imagePublicId?: string;
+  coverImage?: string;
+  coverImagePublicId?: string;
 }
 
 export const searchUserFn = async (searchparams: string) => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #54 

## 📝작업 내용

> 사용자 목록 가져와서 이미지가 있으면 해당 이미지, 없으면 디폴트이미지로 수정했습니다.

## 📸 스크린샷
<img width="365" alt="스크린샷 2024-12-10 오전 11 19 13" src="https://github.com/user-attachments/assets/b3490ac1-6535-4076-898e-5e04af04a75e">

