### PR TITLE
[FEAT] 사이드바 토글 전역상태관리

### DIFF
--- a/src/components/rootlayout/Sidebar.tsx
+++ b/src/components/rootlayout/Sidebar.tsx
@@ -3,6 +3,7 @@ import ChannelList from "../ChannelList";
 import UserListModal from "../userlistModal/UserListModal";
 import UserProfile from "../UserProfile";
 import { twMerge } from "tailwind-merge";
+import { usesidebarToggleStore } from "../../stores/sideberToggleStore";
 // 아이콘
 import dumbbell from "../../assets/dumbbell_icon.svg";
 import protein from "../../assets/protein_icon.svg";
@@ -16,11 +17,12 @@ export default function Sidebar() {
   // 유저 목록 모달 상태
   const [isOpen, setIsOpen] = useState(false);
   // 사이드바 토글 상태
-  const [isToggleOpen, setIsToggleOpen] = useState(true);
+  const isToggle = usesidebarToggleStore((state) => state.isToggle);
+  const sidebarToggle = usesidebarToggleStore((state) => state.sidebarToggle);
 
   const handleToggleClick = () => {
-    console.log(isToggleOpen);
-    setIsToggleOpen(!isToggleOpen);
+    // console.log(isToggle);
+    sidebarToggle();
   };
 
   const handleBackClick = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -77,7 +79,7 @@ export default function Sidebar() {
       py-5 gap-8 text-[#1D1D1D] bg-[#FEFEFE] border-r
       border-gray-200/50 fixed transition-all `,
         isOpen ? "before:modal-back" : "",
-        isToggleOpen ? "w-[300px]" : "w-20"
+        isToggle ? "w-[300px]" : "w-20"
       )}
       onClick={(e) => handleBackClick(e)}
     >
@@ -86,16 +88,13 @@ export default function Sidebar() {
         onClick={handleToggleClick}
         className={twMerge(
           "self-end w-10 mr-2 hover:brightness-95 transition-all",
-          !isToggleOpen && "m-auto"
+          !isToggle && "m-auto"
         )}
       >
-        <img src={isToggleOpen ? left : right} alt="" />
+        <img src={isToggle ? left : right} alt="" />
       </button>
       {/* 로고 */}
-      <a
-        className={twMerge("w-20 h-[53px]", !isToggleOpen && "hidden")}
-        href="/"
-      >
+      <a className={twMerge("w-20 h-[53px]", !isToggle && "hidden")} href="/">
         <img src="/src/assets/loge.svg" alt="loge" />
       </a>
       {/* 멘트 */}
@@ -103,7 +102,7 @@ export default function Sidebar() {
         <div
           className={twMerge(
             "flex flex-col items-center text-xl font-bold text-center",
-            !isToggleOpen && "hidden"
+            !isToggle && "hidden"
           )}
         >
           <div>
@@ -116,7 +115,7 @@ export default function Sidebar() {
           <div>오늘도 운동 완료하셨나요?</div>
         </div>
         {/* 유저 프로필 */}
-        {isToggleOpen && (
+        {isToggle && (
           <UserProfile
             edit
             BackWidth="w-[122px]"
@@ -138,8 +137,8 @@ export default function Sidebar() {
                   alt={item.alt}
                   route={item.route}
                   key={item.id}
-                  toggleStyle={isToggleOpen ? "" : "p-0 justify-center"}
-                  isToggleOpen={isToggleOpen}
+                  toggleStyle={isToggle ? "" : "p-0 justify-center"}
+                  isToggleOpen={isToggle}
                 >
                   {item.title}
                 </ChannelList>
@@ -151,7 +150,7 @@ export default function Sidebar() {
         <button
           className={twMerge(
             "self-center w-[243px] h-[50px] bg-[#3B6CB4] rounded-[20px] text-xl text-white font-bold relative",
-            !isToggleOpen && "hidden"
+            !isToggle && "hidden"
           )}
           onClick={(e) => {
             e.stopPropagation();
@@ -160,7 +159,7 @@ export default function Sidebar() {
         >
           유저 목록
         </button>
-        <button className={twMerge(isToggleOpen && "hidden")}>
+        <button className={twMerge(isToggle && "hidden")}>
           <img
             src={user}
             alt="유저아이콘"

--- a/src/components/rootlayout/Sidebar.tsx
+++ b/src/components/rootlayout/Sidebar.tsx
@@ -37,7 +37,7 @@ export default function Sidebar() {
       route: "/",
     },
     {
-      id: 1,
+      id: 2,
       title: "프로틴 추천",
       icon: protein,
       alt: "프로틴 아이콘",

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,14 +1,22 @@
 import { Outlet } from "react-router";
 import Header from "../components/rootlayout/Header";
 import Sidebar from "../components/rootlayout/Sidebar";
+import { usesidebarToggleStore } from "../stores/sideberToggleStore";
+import { twMerge } from "tailwind-merge";
 
 export default function RootLayout() {
+  const isToggle = usesidebarToggleStore((state) => state.isToggle);
   return (
     <div className="flex">
       <Sidebar />
       <div className="flex flex-col h-screen min-h-screen w-full">
         <Header />
-        <div className="h-full pl-[300px]">
+        <div
+          className={twMerge(
+            "h-full pl-[300px] transition-all",
+            !isToggle && "pl-20"
+          )}
+        >
           <Outlet />
         </div>
       </div>

--- a/src/stores/sideberToggleStore.ts
+++ b/src/stores/sideberToggleStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface sidebarToggle {
+  isToggle: boolean;
+  sidebarToggle: () => void;
+}
+
+export const usesidebarToggleStore = create<sidebarToggle>((set) => ({
+  isToggle: true,
+  sidebarToggle: () => set((state) => ({ isToggle: !state.isToggle })),
+}));


### PR DESCRIPTION
## #️⃣연관된 이슈
#59 

> ex) #이슈번호, #이슈번호

## 📝작업 내용
- 사이드바 토글 상태 전역으로 변경했습니다
- 레이아웃 피드 부분 패딩값 토글 상태에 따라 변경되도록 처리했습니다

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/3fc64ce5-0a1b-4d33-bdd2-e816ce16f394)


## 💬리뷰 요구사항(선택)
