### PR TITLE
[FEAT]#67_isloggedin_Header

### DIFF
--- a/src/components/ButtonComponent.tsx
+++ b/src/components/ButtonComponent.tsx
@@ -1,17 +1,8 @@
-import { useNavigate } from "react-router";
 import { twMerge } from "tailwind-merge";
 
 import React from "react";
 
-interface ButtonComponentProps {
-  bgcolor?: string;
-  textcolor?: string;
-  children: React.ReactNode;
-  onClick?: () => void;
-  className?: string;
-}
-
-const ButtonComponent: React.FC<ButtonComponentProps> = ({
+const ButtonComponent: React.FC<ButtonComponent> = ({
   bgcolor,
   textcolor,
   children,

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -8,6 +8,7 @@ export default function UserProfile({
   BackHeight,
   IconWidth,
   IconHeight,
+  onClick,
 }: userProfileType) {
   return (
     <div
@@ -21,6 +22,7 @@ export default function UserProfile({
         className={twMerge(IconWidth, IconHeight)}
         src={defaultUser}
         alt="userProfile"
+        onClick={onClick}
       />
       {/* edit 기능 있는 유저 프로필 */}
       {edit && (
@@ -28,6 +30,7 @@ export default function UserProfile({
           className="absolute right-[-10px] bottom-[-10px]"
           src={profileEdit}
           alt="profile-edit"
+          onClick={onClick}
         />
       )}
     </div>

--- a/src/components/rootlayout/Header.tsx
+++ b/src/components/rootlayout/Header.tsx
@@ -4,14 +4,29 @@ import { twMerge } from "tailwind-merge";
 import logoImg from "../../assets/loge.svg";
 import UserProfile from "../UserProfile";
 import ButtonComponent from "../ButtonComponent";
+import { useAuth } from "../../stores/authStore";
+import React from "react";
 
 export default function Header({ logo }: { logo?: boolean }) {
   const navigate = useNavigate();
 
+  // Todo : 테스트 로그인 변경기능, 로그인 기능 개발 이후 연동후에 삭제해야함
+  const [testlogin, settestlogin] = React.useState(false);
+  const testloginHandler = () => {
+    settestlogin(!testlogin);
+  };
+  // 여기까지
+
+  // Todo : 로그인기능 구현 후에 이 값으로 로그인 분기처리
+  const isLoggedin = useAuth().isLoggedIn;
+
+  // Todo : 로그아웃기능 구현
+  const logout = () => {};
+
   return (
     <header
       className={twMerge(
-        "h-[70px] flex items-center justify-end px-[36px] py-[8px] ",
+        "h-[70px] flex items-center justify-end px-[36px] py-[20px] ",
         logo ? "justify-between" : "justify-end"
       )}
     >
@@ -23,44 +38,70 @@ export default function Header({ logo }: { logo?: boolean }) {
           onClick={() => navigate("/")}
         />
       </div>
+      <button className="mx-4" onClick={testloginHandler}>
+        테스트 로그인
+      </button>
+      {testlogin ? (
+        // 로그인 상태 분기
+        <div className="flex gap-[10px] items-center">
+          <p className="mx-10">로그인상태</p>
 
-      {/* 오른쪽 */}
+          <ButtonComponent
+            bgcolor="bg-white"
+            textcolor="text-[#265CAC]"
+            // Todo : 로그이웃기능 zustand에서 로그인이 구현하는것 보고 추후 처리
+            onClick={() => useAuth().logout()}
+          >
+            {"로그아웃"}
+          </ButtonComponent>
 
-      <div className="flex gap-[10px] items-center">
-        <ButtonComponent
-          bgcolor="bg-[#265CAC]"
-          textcolor="text-white"
-          onClick={() => navigate("/login")}
-        >
-          {"로그인"}
-        </ButtonComponent>
-        <ButtonComponent
-          bgcolor="bg-white"
-          textcolor="text-[#265CAC]"
-          onClick={() => navigate("/signup")}
-        >
-          {"가입하기"}
-        </ButtonComponent>
-
-        {/*  유저 프로필 */}
-        {/* <div className="bg-white w-[48px] h-[48px] ml-[10px] flex justify-center items-center rounded-[50%] shadow-profile-inner cursor-pointer">
+          {/* {!isLoggedIn && } */}
+          {/*  유저 프로필 */}
+          {/* <div className="bg-white w-[48px] h-[48px] ml-[10px] flex justify-center items-center rounded-[50%] shadow-profile-inner cursor-pointer">
           <img
             src={defaultUser}
             alt="기본 유저사진"
             className="w-[33px] h-[33px]"
           />
         </div> */}
-        <div className="w-[48px] h-[48px]  flex justify-center items-center mx-[10px]">
-          <img src={notifyIcon} alt="알림 아이콘" className="cursor-pointer" />
-        </div>
 
-        <UserProfile
-          BackWidth="w-[48px]"
-          BackHeight="h-[48px]"
-          IconWidth="w-[33px]"
-          IconHeight="h-[33px]"
-        />
-      </div>
+          <div className="w-[48px] h-[48px]  flex justify-center items-center mx-[10px]">
+            <img
+              src={notifyIcon}
+              alt="알림 아이콘"
+              className="cursor-pointer"
+              onClick={() => {}}
+            />
+          </div>
+
+          <UserProfile
+            BackWidth="w-[48px]"
+            BackHeight="h-[48px]"
+            IconWidth="w-[33px]"
+            IconHeight="h-[33px]"
+            onClick={() => {}}
+          />
+        </div>
+      ) : (
+        // 비로그인 상태 분기
+        <div className="flex gap-[10px] items-center">
+          <p>비로그인상태</p>
+          <ButtonComponent
+            bgcolor="bg-[#265CAC]"
+            textcolor="text-white"
+            onClick={() => navigate("/login")}
+          >
+            {"로그인"}
+          </ButtonComponent>
+          <ButtonComponent
+            bgcolor="bg-white"
+            textcolor="text-[#265CAC]"
+            onClick={() => navigate("/signup")}
+          >
+            {"가입하기"}
+          </ButtonComponent>
+        </div>
+      )}
     </header>
   );
 }

--- a/src/types/ButtonComponent.d.ts
+++ b/src/types/ButtonComponent.d.ts
@@ -1,0 +1,7 @@
+interface ButtonComponent {
+  bgcolor?: string;
+  textcolor?: string;
+  children: React.ReactNode;
+  onClick?: () => void;
+  className?: string;
+}

--- a/src/types/UserProfile.d.ts
+++ b/src/types/UserProfile.d.ts
@@ -4,4 +4,5 @@ interface userProfileType {
   BackHeight: string;
   IconWidth: string;
   IconHeight: string;
+  onClick?: () => void;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#67

## 📝작업 내용

헤더에서 로그인 / 로그아웃 상태에 따라 보여주는 분기 분리처리
추후 로그인쪽 개발 완료되는 대로 해야 할 Todo영역은 주석처리로 표기해두었습니다

## 📸 스크린샷
로그아웃상태 
![image](https://github.com/user-attachments/assets/b827daf8-0d72-4dfe-88b3-6f535fe5229e)

로그인상태
![image](https://github.com/user-attachments/assets/c10fc335-c095-4dcf-8cef-affe1a0b0aa8)


## 💬리뷰 요구사항(선택)
-비고
userProfiletype 인터페이스에 onClick 인자 추가하였습니다
통일성을 위해 ButtonComponent 인터페이스도 별도파일로 분리하여 이관하였습니다