### PR TITLE
[FEAT] : private 라우터 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Error from "./pages/Error";
 import AuthLayout from "./layouts/AuthLayout";
 import User from "./pages/User";
 import Posting from "./pages/Posting";
+import PublicRoute from "./route/PublicRoute";
 
 export default function App() {
   return (
@@ -22,9 +23,11 @@ export default function App() {
           <Route path="*" element={<Error />} />
         </Route>
 
-        <Route element={<AuthLayout />}>
-          <Route path="/login" element={<Login />} />
-          <Route path="/signup" element={<Signup />} />
+        <Route element={<PublicRoute />}>
+          <Route element={<AuthLayout />}>
+            <Route path="/login" element={<Login />} />
+            <Route path="/signup" element={<Signup />} />
+          </Route>
         </Route>
       </Routes>
     </>

--- a/src/route/PrivateRoute.tsx
+++ b/src/route/PrivateRoute.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from "react-router";
+import { useAuth } from "../stores/authStore";
+import { Navigate } from "react-router";
+
+// 로그인이 안되어있으면 로그인 페이지로 이동
+// 아직 어느 페이지에 적용할지 미정
+
+export default function PrivateRoute() {
+  const isLoggedIn = useAuth((state) => state.isLoggedIn);
+  return isLoggedIn ? <Outlet /> : <Navigate to="/login" />;
+}

--- a/src/route/PublicRoute.tsx
+++ b/src/route/PublicRoute.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from "react-router";
+import { useAuth } from "../stores/authStore";
+import { Navigate } from "react-router";
+
+// 로그인이 되어이있으면 메인페이지로 이동
+// 로그인, 회원가입 페이지에 적용
+export default function PublicRoute() {
+  const isLoggedIn = useAuth((state) => state.isLoggedIn);
+  return isLoggedIn ? <Navigate to="/" /> : <Outlet />;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #75 

## 📝작업 내용

> private 라우터 기능 구현했습니다.
로그인 상태일 때는 로그인페이지와 회원가입 페이지로 이동하려고하면 메인 페이지로 돌아오도록 설계했습니다.
또한 로그인 안됬을 때는 로그인 페이지로 이동하게 구현했으나 어느 페이지가 다 안나와서 일단은 적용안했습니다.


https://github.com/user-attachments/assets/b0dc786e-e652-4f72-bc59-e6056feb8bff



## 📸 스크린샷

## 💬리뷰 요구사항(선택)
