### PR TITLE
[FEAT]#79_logoOnOffbySidebar_newPostButton

### DIFF
--- a/src/components/rootlayout/Header.tsx
+++ b/src/components/rootlayout/Header.tsx
@@ -5,29 +5,34 @@ import logoImg from "../../assets/loge.svg";
 import UserProfile from "../UserProfile";
 import ButtonComponent from "../ButtonComponent";
 import { useAuth } from "../../stores/authStore";
-import React from "react";
+import React, { useEffect } from "react";
 
-export default function Header({ logo }: { logo?: boolean }) {
+// 사이드바 접힐때 로고 보이도록 처리하자
+export default function Header({
+  logo,
+  sidebar,
+}: {
+  logo?: boolean;
+  sidebar?: boolean;
+}) {
   const navigate = useNavigate();
-
   // Todo : 테스트 로그인 변경기능, 로그인 기능 개발 이후 연동후에 삭제해야함
   const [testlogin, settestlogin] = React.useState(false);
   const testloginHandler = () => {
     settestlogin(!testlogin);
   };
-  // 여기까지
 
   // Todo : 로그인기능 구현 후에 이 값으로 로그인 분기처리
-  const isLoggedin = useAuth().isLoggedIn;
-
+  // const isLoggedin = useAuth().isLoggedIn;
   // Todo : 로그아웃기능 구현
   const logout = () => {};
 
   return (
     <header
       className={twMerge(
-        "h-[70px] flex items-center justify-end px-[36px] py-[20px] ",
-        logo ? "justify-between" : "justify-end"
+        "h-[70px] flex items-center justify-end py-[20px] ",
+        logo ? "justify-between" : "justify-end",
+        sidebar ? "pl-[100px] pr-[36px]" : "px-[36px]"
       )}
     >
       <div>
@@ -38,21 +43,32 @@ export default function Header({ logo }: { logo?: boolean }) {
           onClick={() => navigate("/")}
         />
       </div>
-      <button className="mx-4" onClick={testloginHandler}>
+      <button
+        className="mx-10 items-center justify-center border-solid border"
+        onClick={testloginHandler}
+      >
         테스트 로그인
       </button>
       {testlogin ? (
         // 로그인 상태 분기
         <div className="flex gap-[10px] items-center">
-          <p className="mx-10">로그인상태</p>
+          <p className="mx-10 items-center justify-center">로그인상태</p>
 
           <ButtonComponent
-            bgcolor="bg-white"
-            textcolor="text-[#265CAC]"
+            bgcolor="bg-[#265CAC]"
+            textcolor="text-[white]"
             // Todo : 로그이웃기능 zustand에서 로그인이 구현하는것 보고 추후 처리
             onClick={() => useAuth().logout()}
           >
             {"로그아웃"}
+          </ButtonComponent>
+          <ButtonComponent
+            bgcolor="bg-white"
+            textcolor="text-[#265CAC]"
+            // Todo : 글작성 페이지 도메인으로 변경
+            onClick={() => navigate("/newPost")}
+          >
+            {"새글등록"}
           </ButtonComponent>
 
           {/* {!isLoggedIn && } */}
@@ -79,13 +95,14 @@ export default function Header({ logo }: { logo?: boolean }) {
             BackHeight="h-[48px]"
             IconWidth="w-[33px]"
             IconHeight="h-[33px]"
-            onClick={() => {}}
+            // Todo : 추후 마이페이지 어케 이동하는지 보고 처리
+            onClick={() => navigate("/user/login")}
           />
         </div>
       ) : (
         // 비로그인 상태 분기
         <div className="flex gap-[10px] items-center">
-          <p>비로그인상태</p>
+          <p className="mx-10 items-center justify-left">비로그인상태</p>
           <ButtonComponent
             bgcolor="bg-[#265CAC]"
             textcolor="text-white"

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -10,7 +10,7 @@ export default function RootLayout() {
     <div className="flex">
       <Sidebar />
       <div className="flex flex-col h-screen min-h-screen w-full">
-        <Header />
+        <Header logo sidebar />
         <div
           className={twMerge(
             "h-full pl-[300px] transition-all",


### PR DESCRIPTION
## #️⃣연관된 이슈

#79

## 📝작업 내용

사이드바 있는 레이아웃과 없는 레이아웃에서 로고 표기 위치를 분기처리하고 
사이드바 접혔을 시 로고가 보이도록 처리하였습니다
새글작성 버튼 추가하고
로그아웃 배경색과 텍스트색 반전처리하였습니다

## 📸 스크린샷

사이드바 없을 시 view
![image](https://github.com/user-attachments/assets/e7e077c7-484c-4ef9-9065-8d30c56cc1fd)

사이드바 있을 시 view
![image](https://github.com/user-attachments/assets/c322d100-06f5-46d3-b1e7-790a5befe86d)

로그인 상태의 새글작성 버튼 추가 및 로그아웃 버튼 디자인 변경
![image](https://github.com/user-attachments/assets/3e2bc2bc-5292-4296-b2a2-a82eca202c41)


## 💬리뷰 요구사항(선택)
