### PR TITLE
[FEAT] 새로고침시 로그인 정보와 유저 정보 보관하기

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -7,13 +7,9 @@ import { api } from "../api/axios";
 import { AxiosError } from "axios";
 
 export default function Login() {
-  const user = useAuth((state) => state.user);
-  console.log("유저", user);
-  const isLoggedIn = useAuth((state) => state.isLoggedIn);
   const login = useAuth((state) => state.login);
   const setUser = useAuth((state) => state.setUser);
   const navigate = useNavigate();
-  console.log("로그인상태", isLoggedIn);
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-
+import { PersistOptions, persist } from "zustand/middleware";
 interface UserInfo {
   _id: string;
   email: string;
@@ -29,11 +29,26 @@ interface Auth {
   setUser: (u: UserInfo) => void;
 }
 
-export const useAuth = create<Auth>((set) => ({
-  user: null,
-  isLoggedIn: false,
-  accessToken: null,
-  login: (accessToken: string) => set({ isLoggedIn: true, accessToken }),
-  logout: () => set({ isLoggedIn: false, accessToken: null }),
-  setUser: (u: UserInfo) => set({ user: u }),
-}));
+// export const useAuth = create<Auth>((set) => ({
+//   user: null,
+//   isLoggedIn: false,
+//   accessToken: null,
+//   login: (accessToken: string) => set({ isLoggedIn: true, accessToken }),
+//   logout: () => set({ isLoggedIn: false, accessToken: null }),
+//   setUser: (u: UserInfo) => set({ user: u }),
+// }));
+export const useAuth = create(
+  persist<Auth>(
+    (set) => ({
+      user: null,
+      isLoggedIn: false,
+      accessToken: null,
+      login: (accessToken: string) => set({ isLoggedIn: true, accessToken }),
+      logout: () => set({ isLoggedIn: false, accessToken: null }),
+      setUser: (u: UserInfo) => set({ user: u }),
+    }),
+    {
+      name: "auth-storage", // 로컬 스토리지에 저장될 키 이름
+    }
+  )
+);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #78 

## 📝작업 내용

> zustand persist를 이용해서 스토리지에 저장해서 새로고침시에도 로그인이 유지되게하였습니다.
브라우저의 로컬스토리지를 보면 유저의 정보와 토큰 정보를 저장합니다.
이렇게 가지고 있으면, 로그인이 유지되지만 토큰이 언제 만료될때 로그아웃 처리가 안되서 조금 더 추가해야할거같습니다.

https://github.com/user-attachments/assets/77aae9d1-2745-45b6-8f2f-ffce25f5b38c



## 📸 스크린샷

## 💬리뷰 요구사항(선택)
