### PR TITLE
[Feat]게시글등록-api요청 #88

### DIFF
--- a/src/components/posting/PostStatus.tsx
+++ b/src/components/posting/PostStatus.tsx
@@ -29,7 +29,7 @@ export default function PostStatus({
   }, [img, channel]);
 
   return (
-    <div className="w-[25%] h-[45px] flex items-center justify-between border-t border-[#a3badc] mt-3">
+    <div className="w-[250px] h-[45px] flex items-center justify-between border-t border-[#a3badc] mt-3">
       {/* 아이콘 */}
       <div
         className={`w-[45px] flex flex-col justify-center items-center gap-2`}

--- a/src/components/posting/PostStatus.tsx
+++ b/src/components/posting/PostStatus.tsx
@@ -1,0 +1,104 @@
+import uploadImgIcon from "../../assets/uploadImgIcon.svg";
+import selectChannel from "../../assets/selectChannel.svg";
+import writeTitle from "../../assets/writeTitle.svg";
+import { useEffect, useState } from "react";
+
+interface PostStatusProps {
+  img: string;
+  title: string;
+  desc: string;
+  channel: string;
+}
+
+export default function PostStatus({
+  img,
+  title,
+  desc,
+  channel,
+}: PostStatusProps) {
+  const [iconStatus, setIconStatus] = useState<
+    "upload" | "selectChannel" | "write"
+  >("upload");
+
+  useEffect(() => {
+    if (img.length > 0 && !title && !desc && channel === "게시판 선택")
+      setIconStatus("selectChannel");
+    else if (img.length > 0 && channel !== "게시판 선택" && !title && !desc)
+      setIconStatus("write");
+    else if (img.length < 1) setIconStatus("upload");
+  }, [img, channel]);
+
+  return (
+    <div className="w-[25%] h-[45px] flex items-center justify-between border-t border-[#a3badc] mt-3">
+      {/* 아이콘 */}
+      <div
+        className={`w-[45px] flex flex-col justify-center items-center gap-2`}
+      >
+        <div
+          className={`w-[45px] h-[45px] rounded-[50%] ${
+            iconStatus === "upload" ? "bg-[#265CAC]" : "bg-[#92ADD5]"
+          } flex justify-center items-center `}
+        >
+          <img
+            src={uploadImgIcon}
+            alt="이미지 업로드 아이콘"
+            className="w-[30px] h-[30px] block "
+          />
+        </div>
+        <p
+          className={`${
+            iconStatus === "upload" ? "text-[#265CAC]" : "text-[#92ADD5]"
+          } text-center leading-[16px]`}
+        >
+          이미지 등록
+        </p>
+      </div>
+
+      <div
+        className={`w-[45px] flex flex-col justify-center items-center gap-2`}
+      >
+        <div
+          className={`w-[45px] h-[45px] rounded-[50%] ${
+            iconStatus === "selectChannel" ? "bg-[#265CAC]" : "bg-[#92ADD5]"
+          } flex justify-center items-center`}
+        >
+          <img
+            src={selectChannel}
+            alt="게시판 아이콘"
+            className="w-[30px] h-[30px] block"
+          />
+        </div>
+        <p
+          className={`${
+            iconStatus === "selectChannel" ? "text-[#265CAC]" : "text-[#92ADD5]"
+          } text-center leading-[16px]`}
+        >
+          게시판 선택
+        </p>
+      </div>
+
+      <div
+        className={`w-[45px] flex flex-col justify-center items-center gap-2`}
+      >
+        <div
+          className={`w-[45px] h-[45px] rounded-[50%] ${
+            iconStatus === "write" ? "bg-[#265CAC]" : "bg-[#92ADD5]"
+          } flex justify-center items-center`}
+        >
+          <img
+            src={writeTitle}
+            alt="작성 아이콘"
+            className="w-[30px] h-[30px] block ml-[6px]"
+          />
+        </div>
+        <p
+          className={`${
+            iconStatus === "write" ? "text-[#265CAC]" : "text-[#92ADD5]"
+          } text-center leading-[16px]`}
+        >
+          내용 작성
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Posting.tsx
+++ b/src/pages/Posting.tsx
@@ -1,14 +1,12 @@
 import { useRef, useState } from "react";
 import { twMerge } from "tailwind-merge";
 import downIcon from "../assets/down.svg";
-import uploadImgIcon from "../assets/uploadImgIcon.svg";
-import selectChannel from "../assets/selectChannel.svg";
-import writeTitle from "../assets/writeTitle.svg";
+import PostStatus from "../components/posting/PostStatus";
 
 export default function Posting() {
   const imgRef = useRef<HTMLInputElement>(null);
   // 이미지
-  const [img, setImg] = useState<File>();
+  const [img, setImg] = useState<string>("");
   // 제목
   const [title, setTitle] = useState("");
   // 설명
@@ -21,9 +19,21 @@ export default function Posting() {
 
   const [openChannel, setOpenChannel] = useState(false);
 
+  // 이미지 미리보기
   const handleChange = () => {
     if (imgRef.current && imgRef.current.files) {
       console.log(imgRef.current.files);
+      const image = imgRef.current.files[0];
+      const imgUrl = URL.createObjectURL(image);
+
+      setImg(imgUrl);
+
+      // 다중 이미지 (나중에 api업데이트 시 사용)
+      // for (let i = 0; i < images.length; i++) {
+      //   const imgUrl = URL.createObjectURL(images[i]);
+      //   console.log(imgUrl);
+      //   setImg((prev) => [...prev, imgUrl]);
+      // }
     }
   };
 
@@ -47,54 +57,28 @@ export default function Posting() {
       <div className="m-auto pt-[20px] pb-[20px] h-[650px] bg-white flex flex-col items-center gap-5 rounded-[20px]">
         <h1 className="text-[#030712] font-bold text-[30px]">글쓰기</h1>
         {/* log */}
-        <div className="w-[25%] h-[45px] flex items-center justify-between border-t border-[#a3badc] mt-3">
-          {/* 아이콘 */}
-          <div className="w-[45px] flex flex-col justify-center items-center gap-2 ">
-            <div className="w-[45px] h-[45px] rounded-[50%] bg-[#265CAC] flex justify-center items-center ">
-              <img
-                src={uploadImgIcon}
-                alt="이미지 업로드 아이콘"
-                className="w-[30px] h-[30px] block "
-              />
-            </div>
-            <p className="text-[#265CAC] text-center leading-[16px]">
-              이미지 등록
-            </p>
-          </div>
 
-          <div className="w-[45px] flex flex-col justify-center items-center gap-2">
-            <div className="w-[45px] h-[45px] rounded-[50%] bg-[#92ADD5] flex justify-center items-center">
-              <img
-                src={selectChannel}
-                alt="이미지 업로드 아이콘"
-                className="w-[30px] h-[30px] block"
-              />
-            </div>
-            <p className="text-[#92ADD5] text-center leading-[16px]">
-              게시판 선택
-            </p>
-          </div>
-
-          <div className="w-[45px] flex flex-col justify-center items-center gap-2">
-            <div className="w-[45px] h-[45px] rounded-[50%] bg-[#92ADD5] flex justify-center items-center">
-              <img
-                src={writeTitle}
-                alt="이미지 업로드 아이콘"
-                className="w-[30px] h-[30px] block ml-[6px]"
-              />
-            </div>
-            <p className="text-[#92ADD5] text-center leading-[16px]">
-              내용 작성
-            </p>
-          </div>
-        </div>
+        <PostStatus img={img} title={title} desc={desc} channel={channel} />
 
         <form className="w-[1000px] h-[480px] flex items-center justify-center gap-10 bg-white">
           {/* 이미지 등록 */}
           <div className=" h-[390px] flex flex-col justify-center items-center gap-3">
-            <div className="w-[300px] h-full bg-[#F4F6F8] flex items-center justify-center rounded-[5px]">
+            <div
+              className={`w-[300px] h-full bg-[#F4F6F8] flex  gap-[10px] ${
+                img.length > 0
+                  ? "flex-wrap items-start justify-start"
+                  : "items-center justify-center"
+              }  rounded-[5px]`}
+            >
+              {img.length > 0 && (
+                <img
+                  src={img}
+                  alt="이미지"
+                  className="w-full h-full bg-white"
+                />
+              )}
               <p className="text-[#91989E] w-[80px] text-center">
-                {!img ? "이미지 등록 필수입니다" : ""}
+                {img.length < 1 ? "이미지 등록 필수입니다" : ""}
               </p>
             </div>
             <div>
@@ -152,7 +136,9 @@ export default function Posting() {
               type="text"
               placeholder="제목을 입력해주세요"
               className=" w-full h-[50px] bg-[#F4F6F8]  outline-none text-[18px] px-[15px]"
-              disabled={channelId ? false : true}
+              disabled={img.length && channel !== "게시판 선택" ? false : true}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
             />
             <textarea
               name="desc"
@@ -161,6 +147,8 @@ export default function Posting() {
               className=" resize-none outline-none w-full h-[200px] bg-[#F4F6F8] py-[10px] px-[15px] text-[20px]"
               maxLength={1000}
               disabled={channelId ? false : true}
+              value={desc}
+              onChange={(e) => setDesc(e.target.value)}
             ></textarea>
             <button
               className="bg-[#4772b2] w-[80px] h-[40px] text-white rounded-[10px] cursor-pointer"

--- a/src/pages/Posting.tsx
+++ b/src/pages/Posting.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import { twMerge } from "tailwind-merge";
 import downIcon from "../assets/down.svg";
 import PostStatus from "../components/posting/PostStatus";
+import { postingFn } from "../utils/postingFn";
 
 export default function Posting() {
   const imgRef = useRef<HTMLInputElement>(null);
@@ -24,9 +25,12 @@ export default function Posting() {
     if (imgRef.current && imgRef.current.files) {
       console.log(imgRef.current.files);
       const image = imgRef.current.files[0];
-      const imgUrl = URL.createObjectURL(image);
-
-      setImg(imgUrl);
+      if (image.type.startsWith("image/")) {
+        const imgUrl = URL.createObjectURL(image);
+        setImg(imgUrl);
+      } else {
+        alert("이미지 선택하세요");
+      }
 
       // 다중 이미지 (나중에 api업데이트 시 사용)
       // for (let i = 0; i < images.length; i++) {
@@ -42,7 +46,7 @@ export default function Posting() {
   };
 
   const channels = [
-    { id: "WorkoutDon", name: "오운완 인증" },
+    { id: "6757a3a7ce18fa02ded5c758", name: "오운완 인증" },
     { id: "Protein", name: "프로틴 추천" },
     { id: "Routine", name: "루틴 공유" },
     { id: "Gymreview", name: "헬스장 리뷰" },
@@ -50,6 +54,26 @@ export default function Posting() {
 
   const channelBtnClick = () => {
     setOpenChannel((prev) => !prev);
+  };
+
+  // 보낼 요청값
+  const info = {
+    title: JSON.stringify({ HTitle: title, desc }),
+    image:
+      imgRef.current && imgRef.current.files ? imgRef.current.files[0] : "",
+    channelId,
+  };
+  // 글 등록 요청
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    if (info.image === "") throw new Error("이미지 다시 선택하세요");
+    console.log(info);
+    e.preventDefault();
+    // try {
+    //   const response = await postingFn(info);
+    //   console.log(response);
+    // } catch (error) {
+    //   console.log(error);
+    // }
   };
 
   return (
@@ -60,7 +84,10 @@ export default function Posting() {
 
         <PostStatus img={img} title={title} desc={desc} channel={channel} />
 
-        <form className="w-[1000px] h-[480px] flex items-center justify-center gap-10 bg-white">
+        <form
+          className="w-[1000px] h-[480px] flex items-center justify-center gap-10 bg-white"
+          onSubmit={(e) => handleSubmit(e)}
+        >
           {/* 이미지 등록 */}
           <div className=" h-[390px] flex flex-col justify-center items-center gap-3">
             <div
@@ -87,6 +114,7 @@ export default function Posting() {
                 id="uploadImg"
                 className="hidden"
                 ref={imgRef}
+                accept="image/*"
                 onChange={handleChange}
               />
               <label
@@ -146,13 +174,19 @@ export default function Posting() {
               placeholder="내용을 작성해주세요"
               className=" resize-none outline-none w-full h-[200px] bg-[#F4F6F8] py-[10px] px-[15px] text-[20px]"
               maxLength={1000}
-              disabled={channelId ? false : true}
+              disabled={img.length && channel !== "게시판 선택" ? false : true}
               value={desc}
               onChange={(e) => setDesc(e.target.value)}
             ></textarea>
             <button
-              className="bg-[#4772b2] w-[80px] h-[40px] text-white rounded-[10px] cursor-pointer"
-              disabled
+              className={`w-[80px] h-[40px] text-white rounded-[10px] ${
+                !img.length || channel === "게시판 선택" || !title || !desc
+                  ? "cursor-default bg-[#4772b2a5]"
+                  : "cursor-pointer bg-[#4772b2]"
+              }`}
+              disabled={
+                !img.length || channel === "게시판 선택" || !title || !desc
+              }
             >
               등록하기
             </button>

--- a/src/utils/postingFn.ts
+++ b/src/utils/postingFn.ts
@@ -1,0 +1,21 @@
+import { api } from "../api/axios";
+
+interface PostingFnInfo {
+  title: string;
+  image: File | string;
+  channelId: string;
+}
+
+export const postingFn = async (info: PostingFnInfo) => {
+  try {
+    const response = await api.post("/posts/create", {
+      title: JSON.stringify(info.title),
+      image: info.image,
+      channelId: info.channelId,
+    });
+    console.log(response);
+    return response;
+  } catch (error) {
+    console.log(error);
+  }
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #88 

## 📝작업 내용
작성 진행사항(제목 아래 아이콘)
이미지 선택 -> 게시판 선택 -> 글작성에 맞게 아이콘, 폰트 배경처리 했습니다.

input:file 은 무조건 이미지만 선택 가능하도록 했습니다. 강제적으로 바꾸고 이미지가 아닌 다른 파일 선택 시 경고창 띄웠습니다.

이미지 선택 시 이미지 미리보기를 할 수 있고, 이미지 배경으로는 white색상 넣었습니다.

일단 부제목 부분 글자 수 길이는 1000자로 해놨습니다 수정사항 생기면 말씀해주세요
제목과 부제목을 합쳐서 api요청 보낼때 title값에 한 번에 보내도록 했어요.

이미지, 게시판, 글이나 부제목 작성 네가지 중  한 가지라도 선택이 안되어있거나 작성을 안하면 요청 못하게 막아놨습니다. 

현재 토큰값이 아직 구현이 안되어서 당장 요청보내면 오류납니다. 그리고 저희 채널이 일단 오운완밖에 없어서 오운완 채널로만 요청 보내야합니다.
콘솔로 보낼 값만 찍히게 해놨습니다.

## 📸 스크린샷
<img width="1082" alt="스크린샷 2024-12-11 오전 10 42 30" src="https://github.com/user-attachments/assets/eb4202ec-97ec-4554-8a8e-11f9c855afe3">

