### PR TITLE
[FEAT] 모달창 상세유저페이지 연결, 사이드바 색상 수정

### DIFF
--- a/src/components/ChannelList.tsx
+++ b/src/components/ChannelList.tsx
@@ -24,12 +24,14 @@ export default function ChannelList({
         <li
           className={twMerge(
             "w-full border-r-4",
-            isActive ? "border-[#3B6CB4]" : "border-transparent"
+            isActive ? "border-[#265CAC]" : "border-transparent"
           )}
         >
           <div
             className={twMerge(
-              "flex items-center gap-[10px] w-full h-[50px] pl-6  text-lg font-normal rounded-lg bg-[#FEFEFE] hover:bg-[#EAEAEA] transition cursor-pointer",
+              `flex items-center gap-[10px] w-full h-[50px] pl-6  text-lg font-normal rounded-lg ${
+                isActive ? "bg-[#E8F3FC]" : "bg-[#FEFEFE]"
+              } hover:bg-[#EAEAEA] transition cursor-pointer`,
               toggleStyle // 토글 스타일 지정
             )}
           >

--- a/src/components/rootlayout/Sidebar.tsx
+++ b/src/components/rootlayout/Sidebar.tsx
@@ -155,7 +155,7 @@ export default function Sidebar() {
           <div className="flex justify-center">
             <button
               className={twMerge(
-                "mt-6 self-center w-[243px] h-[50px] bg-[#3B6CB4] rounded-[20px] text-lg text-white font-bold relative",
+                "mt-6 self-center w-[243px] h-[50px] bg-[#265CAC] rounded-[20px] text-lg text-white font-bold relative",
                 !isToggle && "hidden"
               )}
               onClick={(e) => {
@@ -179,7 +179,12 @@ export default function Sidebar() {
           </div>
         </div>
 
-        {isOpen && <UserListModal handleBackClick={handleBackClick} />}
+        {isOpen && (
+          <UserListModal
+            handleBackClick={handleBackClick}
+            setIsOpen={setIsOpen}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/userlistModal/UserBox.tsx
+++ b/src/components/userlistModal/UserBox.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router";
 import defaultUserImg from "../../assets/defaultUser.svg";
 
 interface UserBoxPropsType {
@@ -6,6 +7,8 @@ interface UserBoxPropsType {
   followers: string[];
   following: string[];
   image?: string | null;
+  userid: string;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function UserBox({
@@ -14,11 +17,22 @@ export default function UserBox({
   following,
   isOnline,
   image,
+  userid,
+  setIsOpen,
 }: UserBoxPropsType) {
+  const navigate = useNavigate();
+
+  const handleClick = (userId: string) => {
+    setIsOpen(false);
+    navigate(`/user/${userId}`);
+  };
   return (
     <div className="w-[320px] h-[75px] bg-[#EFEFEF] flex items-center gap-3 pl-[20px] rounded-[10px] flex-shrink-0">
       {/* 유저 프로필, 현활 */}
-      <div className="bg-white w-[48px] h-[48px] flex justify-center items-center rounded-[50%] shadow-inner cursor-pointer relative">
+      <div
+        className="bg-white w-[48px] h-[48px] flex justify-center items-center rounded-[50%] shadow-inner cursor-pointer relative"
+        onClick={() => handleClick(userid)}
+      >
         <img
           src={image ? image : defaultUserImg}
           alt="사용자 프로필 사진"

--- a/src/components/userlistModal/UserListModal.tsx
+++ b/src/components/userlistModal/UserListModal.tsx
@@ -9,9 +9,13 @@ import { usesidebarToggleStore } from "../../stores/sideberToggleStore";
 
 interface UserListModalType {
   handleBackClick: (e: React.MouseEvent<HTMLDivElement>) => void;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export default function UserListModal({ handleBackClick }: UserListModalType) {
+export default function UserListModal({
+  handleBackClick,
+  setIsOpen,
+}: UserListModalType) {
   // 토글 상태
   const isToggle = usesidebarToggleStore((state) => state.isToggle);
 
@@ -133,6 +137,8 @@ export default function UserListModal({ handleBackClick }: UserListModalType) {
                   followers={user.followers}
                   following={user.following}
                   image={user.image ? user.image : null}
+                  userid={user._id}
+                  setIsOpen={setIsOpen}
                 />
               ))
             ) : (
@@ -151,6 +157,8 @@ export default function UserListModal({ handleBackClick }: UserListModalType) {
                       following={user.following}
                       isOnline={user.isOnline}
                       image={user.image ? user.image : null}
+                      userid={user._id}
+                      setIsOpen={setIsOpen}
                     />
                   )
               )


### PR DESCRIPTION
## #️⃣연관된 이슈

#101 

## 📝작업 내용
유저목록 모달창에서 유저 프로필 사진 클릭 시 상세 유저페이지로 이동합니다.
중간에 사이드바 색상 수정요청이 들어와서 수정했습니다 !

## 📸 스크린샷
<img width="307" alt="스크린샷 2024-12-11 오후 3 30 09" src="https://github.com/user-attachments/assets/9ee1f2fa-7b24-49df-baba-d6cb3099ce2a">
