### PR TITLE
[FEAT] 마이페이지 이름 수정 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import Posting from "./pages/Posting";
 import PublicRoute from "./route/PublicRoute";
 import PostDetail from "./pages/PostDetail";
 import PrivateRoute from "./route/PrivateRoute";
+import MyPage from "./pages/MyPage";
 
 export default function App() {
   return (
@@ -25,6 +26,7 @@ export default function App() {
           <Route path="*" element={<Error />} />
           <Route element={<PrivateRoute />}>
             <Route path="/posting" element={<Posting />} />
+            <Route path="/myprofile" element={<MyPage />} />
           </Route>
         </Route>
 

--- a/src/components/User/UserCard.tsx
+++ b/src/components/User/UserCard.tsx
@@ -1,27 +1,107 @@
+import { useRef, useState } from "react";
 import FollowButton from "../FollowButton";
 import UserProfile from "../UserProfile";
+import { updateNameFn } from "../../utils/updateName";
 
-export default function UserCard({ uname }: { uname: string }) {
+interface UserCardType {
+  uname: string;
+  followers?: string[];
+  following?: string[];
+  BackWidth: string;
+  BackHeight: string;
+  IconWidth: string;
+  IconHeight: string;
+  isFollowBtn?: boolean;
+  edit?: boolean;
+  update?: boolean;
+}
+
+export default function UserCard({
+  uname,
+  followers,
+  following,
+  BackWidth,
+  BackHeight,
+  IconWidth,
+  IconHeight,
+  isFollowBtn,
+  edit,
+  update,
+}: UserCardType) {
+  const [updateName, setUpdateName] = useState(uname);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleOutFocus = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (updateName === uname) return;
+
+    try {
+      const response = await updateNameFn(e.target.value);
+      console.log(response);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (updateName === uname) return;
+
+    if (e.key === "Enter") {
+      try {
+        const response = await updateNameFn(updateName);
+        console.log(response);
+        inputRef.current?.blur();
+      } catch (error) {
+        console.log(error);
+      }
+    }
+  };
+
   return (
-    <div className="w-[404px] h-[132px] flex justify-between items-center">
+    <div className="w-[350px] h-[132px] flex justify-between items-center">
       <UserProfile
-        BackWidth="w-[132px]"
-        BackHeight="h-[132px]"
-        IconWidth="w-[92px]"
-        IconHeight="h-[92px]"
+        BackWidth={BackWidth}
+        BackHeight={BackHeight}
+        IconWidth={IconWidth}
+        IconHeight={IconHeight}
+        edit={edit}
+        update={update}
       />
       <div>
         <div className="flex mb-6 gap-[32px] items-center">
-          <p className="text-4xl">{uname}</p>
-          <FollowButton
-            width="w-[128px]"
-            height="h-[52px]"
-            rounded="rounded-[15px]"
-          />
+          <p className="text-4xl hidden">{uname}</p>
+          {isFollowBtn && (
+            <FollowButton
+              width="w-[128px]"
+              height="h-[52px]"
+              rounded="rounded-[15px]"
+            />
+          )}
+          {update && (
+            <div className="absolute">
+              <input
+                type="text"
+                id="updateName"
+                className="text-4xl w-[250px]"
+                value={updateName}
+                ref={inputRef}
+                onChange={(e) => setUpdateName(e.target.value)}
+                onBlur={handleOutFocus}
+                onKeyDown={handleKeyDown}
+              />
+              <label
+                htmlFor="updateName"
+                className="ml-5 text-[18px] text-[#265CAC] underline
+                cursor-pointer"
+              >
+                수정
+              </label>
+            </div>
+          )}
         </div>
         <div className="flex text-2xl gap-[28px]">
-          <p>팔로워: 0</p>
-          <p>팔로우: 0</p>
+          <p>팔로워: {followers && followers.length}</p>
+          <p>팔로우: {following && following.length}</p>
         </div>
       </div>
     </div>

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -1,6 +1,7 @@
 import { twMerge } from "tailwind-merge";
 import defaultUser from "../assets/defaultUser.svg";
 import profileEdit from "../assets/profile-edit.svg";
+import { useRef, useState } from "react";
 
 export default function UserProfile({
   edit,
@@ -9,7 +10,12 @@ export default function UserProfile({
   IconWidth,
   IconHeight,
   onClick,
+  update,
 }: userProfileType) {
+  const [updateImg, setUpdateImg] = useState("");
+  const imgRef = useRef(null);
+
+  const imgUpdate = () => {};
   return (
     <div
       className={twMerge(
@@ -24,6 +30,7 @@ export default function UserProfile({
         alt="userProfile"
         onClick={onClick}
       />
+
       {/* edit 기능 있는 유저 프로필 */}
       {edit && (
         <img
@@ -33,6 +40,26 @@ export default function UserProfile({
           onClick={onClick}
         />
       )}
+
+      {/* 업데이트 기능이 있는 유저 */}
+      {update ? (
+        <form>
+          <input
+            type="file"
+            accept="image/*"
+            className="hidden"
+            id="editProfileImg"
+            ref={imgRef}
+          />
+          <label htmlFor="editProfileImg">
+            <img
+              className="absolute right-[-10px] bottom-[-10px] cursor-pointer"
+              src={profileEdit}
+              alt="profile-edit"
+            />
+          </label>
+        </form>
+      ) : null}
     </div>
   );
 }

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,0 +1,96 @@
+import UserCard from "../components/User/UserCard";
+import { useAuth } from "../stores/authStore";
+import UserProfile from "../components/UserProfile";
+import thumbnail from "../assets/images/feed_thumbnail.jpg";
+import likeIcon from "../assets/like_icon.svg";
+import chatIcon from "../assets/chat_icon.svg";
+
+export default function MyPage() {
+  const myInfo = useAuth((state) => state.user)!;
+  console.log(myInfo);
+
+  const update = new Date();
+  const date = update.toLocaleDateString("ko-KR").slice(0, -1);
+
+  return (
+    <div className="w-full flex flex-col items-center">
+      <div className=" w-[1200px] flex flex-col gap-[40px]">
+        <UserCard
+          uname={myInfo.fullName}
+          followers={myInfo.followers}
+          following={myInfo.following}
+          BackWidth="w-[100px]"
+          BackHeight="h-[100px]"
+          IconWidth="w-[80px]"
+          IconHeight="h-[80px]"
+          edit={true}
+          update={true}
+        />
+
+        <div>
+          <p className="font-semibold text-[22px] mb-[20px]">
+            게시물 {myInfo.posts.length}개
+          </p>
+          <div className="flex items-center justify-center">
+            <div className="grid gap-8 2xl:grid-cols-4 xl:grid-cols-3 lg:grid-cols-2">
+              {/* imageCard 부분 타입 충돌이 있어서 따로 가져왔습니다. */}
+              {myInfo.posts.map((post) => {
+                const update = new Date();
+                const date = update.toLocaleDateString("ko-KR").slice(0, -1);
+
+                return (
+                  <div
+                    className="flex flex-col items-center gap-3"
+                    key={post._id}
+                  >
+                    {/* 썸네일 */}
+                    <div
+                      className="group relative w-[250px] h-[250px] bg-cover bg-center rounded-2xl shadow-lg"
+                      style={{
+                        backgroundImage: `url(${post.image || thumbnail})`,
+                      }}
+                    >
+                      {/* Hover */}
+                      <div className="absolute inset-0 flex flex-col items-center justify-center text-white transition-opacity duration-300 bg-black bg-opacity-50 rounded-lg opacity-0 group-hover:opacity-100">
+                        <h3 className="w-[80%] text-[20px] font-semibold truncate">
+                          {post.title}
+                        </h3>
+                        {/* 아이콘 */}
+                        <div className="absolute bottom-6 right-6 flex gap-[18px] text-xl font-normal ">
+                          <div className="flex gap-1">
+                            <img src={likeIcon} alt="좋아요 아이콘" />
+                            <span>{post.likes.length}</span>
+                          </div>
+                          <div className="flex gap-1">
+                            <img src={chatIcon} alt="채팅 아이콘" />
+                            <span>{post.comments.length}</span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* 글 작성자 정보 */}
+                    <div className="flex items-center justify-between w-full px-2">
+                      <div className="flex items-center gap-[10px]">
+                        <UserProfile
+                          BackWidth="w-[40px]"
+                          BackHeight="h-[40px]"
+                          IconWidth="w-[28px]"
+                          IconHeight="h-[28px]"
+                        />
+                        <div className="text-base font-medium">
+                          {myInfo.fullName}
+                        </div>
+                      </div>
+                      <div className="text-base font-light">{date}</div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/User.tsx
+++ b/src/pages/User.tsx
@@ -7,7 +7,13 @@ export default function User() {
   return (
     <div className="flex flex-col items-center">
       <div className="border-2 border-blue-500 gap-[68px] flex flex-col mt-[120px]">
-        <UserCard uname={`유저${user_id}`} />
+        <UserCard
+          uname={`유저${user_id}`}
+          BackWidth="w-[132px]"
+          BackHeight="h-[132px]"
+          IconWidth="w-[92px]"
+          IconHeight="h-[92px]"
+        />
         <div>
           게시물 12개
           <div className="flex items-center">

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,32 +1,53 @@
 import { create } from "zustand";
 import { PersistOptions, persist } from "zustand/middleware";
-interface UserInfo {
+
+// 내정보랑 유저정보의 타입에서 posts부분이 조금 다른게 있어서 변경했습니다 기존의 UserInfo 타입은
+// UserInfo.d.ts파일에 넣어놨습니다. 확인하시고 주석지워주세요
+interface MyInfo {
+  role: string;
+  emailVerified: false;
+  banned: false;
+  isOnline: true;
+  posts: MyInfoPost[];
+  likes: string[];
+  comments: string[];
+  followers: string[];
+  following: string[];
+  notifications: string[];
+  messages: string[];
   _id: string;
-  email: string;
-  emailVerified: boolean;
   fullName: string;
-  role: string; // 예시로 "Regular"와 "Admin" 역할을 추가했습니다. 다른 역할이 있을 경우 수정 가능.
-  banned: boolean;
-  isOnline: boolean;
-  createdAt: string; // ISO 8601 형식의 날짜 문자열
-  updatedAt: string; // ISO 8601 형식의 날짜 문자열
-  followers: string[]; // 팔로워 목록 (user ID 배열)
-  following: string[]; // 팔로우 목록 (user ID 배열)
-  likes: string[]; // 좋아요 목록 (post ID 배열)
-  comments: string[]; // 댓글 목록 (comment ID 배열)
-  messages: string[]; // 메시지 목록 (message ID 배열)
-  notifications: string[]; // 알림 목록 (notification ID 배열)
-  posts: string[]; // 게시물 목록 (post ID 배열)
-  __v: number; // 버전 번호 (MongoDB의 internal version)
+  email: string;
+  createdAt: string;
+  updatedAt: string;
+  __v: 0;
+  image: string;
+  imagePublicId: string;
+  coverImage: string;
+  coverImagePublicId: string;
+}
+
+interface MyInfoPost {
+  likes: string[];
+  comments: string[];
+  _id: string;
+  title: string;
+  image: string;
+  imagePublicId: string;
+  channel: string;
+  author: string;
+  createdAt: string;
+  updatedAt: string;
+  __v: number;
 }
 
 interface Auth {
-  user: UserInfo | null;
+  user: MyInfo | null;
   isLoggedIn: boolean;
   accessToken: string | null;
   login: (accessToken: string) => void;
   logout: () => void;
-  setUser: (u: UserInfo) => void;
+  setUser: (u: MyInfo) => void;
 }
 
 // export const useAuth = create<Auth>((set) => ({
@@ -35,7 +56,7 @@ interface Auth {
 //   accessToken: null,
 //   login: (accessToken: string) => set({ isLoggedIn: true, accessToken }),
 //   logout: () => set({ isLoggedIn: false, accessToken: null }),
-//   setUser: (u: UserInfo) => set({ user: u }),
+//   setUser: (u: MyInfo) => set({ user: u }),
 // }));
 export const useAuth = create(
   persist<Auth>(
@@ -45,7 +66,7 @@ export const useAuth = create(
       accessToken: null,
       login: (accessToken: string) => set({ isLoggedIn: true, accessToken }),
       logout: () => set({ isLoggedIn: false, accessToken: null }),
-      setUser: (u: UserInfo) => set({ user: u }),
+      setUser: (u: MyInfo) => set({ user: u }),
     }),
     {
       name: "auth-storage", // 로컬 스토리지에 저장될 키 이름

--- a/src/types/UserInfo.d.ts
+++ b/src/types/UserInfo.d.ts
@@ -1,0 +1,19 @@
+interface UserInfo {
+  _id: string;
+  email: string;
+  emailVerified: boolean;
+  fullName: string;
+  role: string; // 예시로 "Regular"와 "Admin" 역할을 추가했습니다. 다른 역할이 있을 경우 수정 가능.
+  banned: boolean;
+  isOnline: boolean;
+  createdAt: string; // ISO 8601 형식의 날짜 문자열
+  updatedAt: string; // ISO 8601 형식의 날짜 문자열
+  followers: string[]; // 팔로워 목록 (user ID 배열)
+  following: string[]; // 팔로우 목록 (user ID 배열)
+  likes: string[]; // 좋아요 목록 (post ID 배열)
+  comments: string[]; // 댓글 목록 (comment ID 배열)
+  messages: string[]; // 메시지 목록 (message ID 배열)
+  notifications: string[]; // 알림 목록 (notification ID 배열)
+  posts: string[]; // 게시물 목록 (post ID 배열)
+  __v: number; // 버전 번호 (MongoDB의 internal version)
+}

--- a/src/types/UserProfile.d.ts
+++ b/src/types/UserProfile.d.ts
@@ -5,4 +5,5 @@ interface userProfileType {
   IconWidth: string;
   IconHeight: string;
   onClick?: () => void;
+  update?: boolean;
 }

--- a/src/utils/updateName.ts
+++ b/src/utils/updateName.ts
@@ -1,0 +1,13 @@
+import { api } from "../api/axios";
+
+export const updateNameFn = async (fullName: string) => {
+  try {
+    const response = await api.put("/settings/update-user", {
+      fullName,
+    });
+    console.log(response);
+    return response;
+  } catch (error) {
+    console.log(error);
+  }
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #119 

## 📝작업 내용

**중간 점검입니다**

마이페이지 작업했습니다.
1. auth store에 있는 유저 타입과 실제로 가져오는 유저의 타입이 조금 달라서 타입부분 수정했습니다. 
2. 이미지카드 컴포넌트를 사용할 수가 없습니다. 로그인을 했을 때 받아오는 정보와 일반적으로 게시글을 불러오는 정보가 살짝 다릅니다. 거의 비슷하긴하지만, 타입 충돌이 너무 심해서 아예 복사하고 사용했습니다.
3. 현재 로그인 후, 새 글을 등록하거나, 이름 수정은 정상적으로 가능하지만 새로고침을 해도 변경된 사항이 보이질 않고 전에 있던 정보가 보입니다. 로그아웃 후 새로 로그인을 해야 변경된 사항이 보이는데 이 버그를 auth에서 잡아야할지 수정이나 등록 후에 로직을 따로 처리해야할지 고민됩니다.

## 📸 스크린샷
<img width="1328" alt="스크린샷 2024-12-12 오전 10 42 10" src="https://github.com/user-attachments/assets/d1c4fb04-7b58-447c-9185-9d636dab1d65" />


