### PR TITLE
[FEAT] 로그인 상태관리 수정 및 사이드바 유저 정보 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,8 @@ export default function App() {
     verifyUser();
   }, [path]);
   return (
+    // 잠시 private 라우터 지우겠습니다.
+    // 수정해야할거같습니다.
     <>
       <Routes>
         <Route element={<RootLayout />}>
@@ -37,10 +39,8 @@ export default function App() {
           <Route path="/about" element={<About />} />
           <Route path="/user/:user_id" element={<User />} />
           <Route path="*" element={<Error />} />
-          <Route element={<PrivateRoute />}>
-            <Route path="/posting" element={<Posting />} />
-            <Route path="/myprofile" element={<MyPage />} />
-          </Route>
+          <Route path="/posting" element={<Posting />} />
+          <Route path="/myprofile" element={<MyPage />} />
         </Route>
 
         <Route element={<PublicRoute />}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
-import { Route } from "react-router";
-import { Routes } from "react-router";
+import { Route, useLocation, Routes } from "react-router";
 import Home from "./pages/Home";
 import About from "./pages/About";
 import RootLayout from "./layouts/RootLayout";
@@ -14,8 +13,15 @@ import PostDetail from "./pages/PostDetail";
 import PrivateRoute from "./route/PrivateRoute";
 import ReviewPost from "./pages/ReviewPost";
 import MyPage from "./pages/MyPage";
+import { useEffect } from "react";
+import { verifyUser } from "./utils/verifyUser";
 
 export default function App() {
+  const path = useLocation();
+
+  useEffect(() => {
+    verifyUser();
+  }, [path]);
   return (
     <>
       <Routes>

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,13 +1,13 @@
 import axios from "axios";
-import { useAuth } from "../stores/authStore";
+import { useToken } from "../stores/toeknStore";
 
 export const api = axios.create({
   baseURL: "https://5th.fe.dev-cos.com:5001",
 });
 
-api.interceptors.request.use((config) => {
+api.interceptors.request.use(async (config) => {
   // 토큰 가져오기
-  const token = useAuth.getState().accessToken;
+  const token = useToken.getState().accessToken;
   // 토큰이 있으면 요청 헤더에 추가
   if (token) {
     config.headers["Authorization"] = `Bearer ${token}`;

--- a/src/components/rootlayout/Header.tsx
+++ b/src/components/rootlayout/Header.tsx
@@ -9,6 +9,7 @@ import React, { useEffect, useState } from "react";
 import { api } from "../../api/axios";
 import { AxiosError } from "axios";
 import Notification from "../notification/Notification";
+import { useToken } from "../../stores/toeknStore";
 
 // 사이드바 접힐때 로고 보이도록 처리하자
 export default function Header({
@@ -18,6 +19,7 @@ export default function Header({
   logo?: boolean;
   sidebar?: boolean;
 }) {
+  const setToken = useToken((state) => state.setToken);
   const navigate = useNavigate();
   const authInfo = useAuth();
   {
@@ -39,7 +41,8 @@ export default function Header({
         email: "wjw1469@gmail.com",
         password: "asdf1234",
       });
-      login(data.token);
+      setToken(data.token);
+      login();
       setUser(data.user);
       alert("로그인 되었습니다.");
       navigate("/");
@@ -57,7 +60,7 @@ export default function Header({
   const logout = () => {
     authInfo.logout();
     // 로컬스토리지 삭제
-    useAuth.persist.clearStorage();
+    useToken.persist.clearStorage();
   };
 
   //

--- a/src/components/rootlayout/Header.tsx
+++ b/src/components/rootlayout/Header.tsx
@@ -150,7 +150,7 @@ export default function Header({
             IconWidth="w-[33px]"
             IconHeight="h-[33px]"
             // Todo : 추후 마이페이지 어케 이동하는지 보고 처리
-            onClick={() => navigate("/user/login")}
+            onClick={() => navigate("/myprofile")}
           />
         </div>
       ) : (

--- a/src/components/rootlayout/Sidebar.tsx
+++ b/src/components/rootlayout/Sidebar.tsx
@@ -13,8 +13,13 @@ import left from "../../assets/double-left.svg";
 import right from "../../assets/double-right.svg";
 import user from "../../assets/user_icon.svg";
 import ModeChange from "../button/ModeChange";
+import { useAuth } from "../../stores/authStore";
 
 export default function Sidebar() {
+  //로그인상태
+  const isLoggedIn = useAuth((state) => state.isLoggedIn);
+  // 유저정보
+  const userInfo = useAuth((state) => state.user);
   // 유저 목록 모달 상태
   const [isOpen, setIsOpen] = useState(false);
   // 사이드바 토글 상태
@@ -117,7 +122,7 @@ export default function Sidebar() {
           <div>
             어서오세요{" "}
             <span className="text-[#265CAC] text-[26px] font-extrabold">
-              수영
+              {userInfo && isLoggedIn ? userInfo.fullName : "회원"}
             </span>
             님
           </div>
@@ -156,7 +161,7 @@ export default function Sidebar() {
             })}
           </ul>
         </div>
-        <div className=" items-center ">
+        <div className="items-center ">
           {/* 모드변경 버튼 */}
           <div className="flex justify-center">
             <ModeChange />

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -5,9 +5,12 @@ import { twMerge } from "tailwind-merge";
 import { useAuth } from "../stores/authStore";
 import { api } from "../api/axios";
 import { AxiosError } from "axios";
+import { useToken } from "../stores/toeknStore";
 
 export default function Login() {
   const login = useAuth((state) => state.login);
+  // 토큰 저장하기
+  const setToken = useToken((state) => state.setToken);
   const setUser = useAuth((state) => state.setUser);
 
   const navigate = useNavigate();
@@ -40,8 +43,9 @@ export default function Login() {
         password,
       });
       // 토큰 저장하기
-      login(data.token);
-      console.log(data, status);
+      setToken(data.token);
+      // 로그인
+      login();
       setUser(data.user);
       alert("로그인 되었습니다.");
       // Todo -> 로그인성공 후 이동페이지

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -3,51 +3,53 @@ import { useAuth } from "../stores/authStore";
 import ImageCard from "../components/ImageCard";
 
 export default function MyPage() {
-  const myInfo = useAuth((state) => state.user)!;
+  const myInfo = useAuth((state) => state.user);
   console.log(myInfo);
 
   return (
-    <div className="flex flex-col items-center relative">
-      <div className="w-[1600px] flex flex-col gap-[40px] pt-10">
-        <UserCard
-          uname={myInfo.fullName}
-          followers={myInfo.followers}
-          following={myInfo.following}
-          BackWidth="w-[100px]"
-          BackHeight="h-[100px]"
-          IconWidth="w-[80px]"
-          IconHeight="h-[80px]"
-          edit={true}
-          update={true}
-          userImg={myInfo.image}
-        />
+    <>
+      {myInfo && (
+        <div className="relative flex flex-col items-center">
+          <div className="w-[1600px] flex flex-col gap-[40px] pt-10">
+            <UserCard
+              uname={myInfo.fullName}
+              followers={myInfo.followers}
+              following={myInfo.following}
+              BackWidth="w-[100px]"
+              BackHeight="h-[100px]"
+              IconWidth="w-[80px]"
+              IconHeight="h-[80px]"
+              edit={true}
+              update={true}
+              userImg={myInfo.image}
+            />
 
-        <div className="border-t pt-[10px] px-1 flex justify-center">
-          <div className="flex flex-col items-start mt-[20px]">
-            <p className="text-[22px] mb-[20px] font-bold">
-              게시물 {myInfo.posts.length}개
-            </p>
-            <div className="flex items-center justify-center">
-              <div className="grid gap-8 2xl:grid-cols-4 xl:grid-cols-3 lg:grid-cols-2">
-                {myInfo.posts.map((post) => {
-                  return (
-                    <ImageCard
-                      key={post._id}
-                      image={post.image}
-                      comments={post.comments}
-                      createdAt={post.updatedAt}
-                      likes={post.likes}
-                      title={post.title}
-                      fullName={myInfo.fullName}
-                      userImg={myInfo.image}
-                    />
-                  );
-                })}
+            <div className="border-t pt-[10px] px-1 flex justify-center">
+              <div className="flex flex-col items-start mt-[20px]">
+                <p className="text-[22px] mb-[20px] font-bold">
+                  게시물 {myInfo.posts.length}개
+                </p>
+                <div className="flex items-center justify-center">
+                  <div className="grid gap-8 2xl:grid-cols-4 xl:grid-cols-3 lg:grid-cols-2">
+                    {myInfo.posts.map((post) => (
+                      <ImageCard
+                        key={post._id}
+                        image={post.image}
+                        comments={post.comments}
+                        createdAt={post.updatedAt}
+                        likes={post.likes}
+                        title={post.title}
+                        fullName={myInfo.fullName}
+                        userImg={myInfo.image}
+                      />
+                    ))}
+                  </div>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-    </div>
+      )}
+    </>
   );
 }

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand";
-import { PersistOptions, persist } from "zustand/middleware";
 
 // 내정보랑 유저정보의 타입에서 posts부분이 조금 다른게 있어서 변경했습니다 기존의 UserInfo 타입은
 // UserInfo.d.ts파일에 넣어놨습니다. 확인하시고 주석지워주세요
@@ -44,32 +43,15 @@ interface MyInfoPost {
 interface Auth {
   user: MyInfo | null;
   isLoggedIn: boolean;
-  accessToken: string | null;
-  login: (accessToken: string) => void;
+  login: () => void;
   logout: () => void;
   setUser: (u: MyInfo) => void;
 }
 
-// export const useAuth = create<Auth>((set) => ({
-//   user: null,
-//   isLoggedIn: false,
-//   accessToken: null,
-//   login: (accessToken: string) => set({ isLoggedIn: true, accessToken }),
-//   logout: () => set({ isLoggedIn: false, accessToken: null }),
-//   setUser: (u: MyInfo) => set({ user: u }),
-// }));
-export const useAuth = create(
-  persist<Auth>(
-    (set) => ({
-      user: null,
-      isLoggedIn: false,
-      accessToken: null,
-      login: (accessToken: string) => set({ isLoggedIn: true, accessToken }),
-      logout: () => set({ isLoggedIn: false, accessToken: null }),
-      setUser: (u: MyInfo) => set({ user: u }),
-    }),
-    {
-      name: "auth-storage", // 로컬 스토리지에 저장될 키 이름
-    }
-  )
-);
+export const useAuth = create<Auth>((set) => ({
+  user: null,
+  isLoggedIn: false,
+  login: () => set({ isLoggedIn: true }),
+  logout: () => set({ isLoggedIn: false, user: null }),
+  setUser: (u: MyInfo) => set({ user: u }),
+}));

--- a/src/stores/toeknStore.ts
+++ b/src/stores/toeknStore.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+interface Token {
+  accessToken: string | null;
+  setToken: (accessToken: string) => void;
+}
+export const useToken = create(
+  persist<Token>(
+    (set) => ({
+      accessToken: null,
+      setToken: (accessToken: string) => set({ accessToken }),
+    }),
+    {
+      name: "auth-storage", // 로컬 스토리지에 저장될 키 이름
+    }
+  )
+);

--- a/src/utils/verifyUser.ts
+++ b/src/utils/verifyUser.ts
@@ -1,0 +1,14 @@
+import { api } from "../api/axios";
+import { useAuth } from "../stores/authStore";
+
+const setUser = useAuth.getState().setUser;
+const login = useAuth.getState().login;
+
+export const verifyUser = async () => {
+  const { status, data } = await api.get("/auth-user");
+  if (!data) return;
+  if (status === 200) {
+    setUser(data);
+    login();
+  }
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #150 

## 📝작업 내용

> 로그인 상태관리 수정하였고, 맞는 로직인지는 모르겠으나 페이지 이동할때마다 api를 호출하여 새로운 정보를 가져오도록하였습니다. 일단은 로그아웃 상태일때는 사이드바 부분에 "회원"이라고 표시하였고, 로그인 되어있을 때는 '회원정보'를 가져오게 하였습니다.

![image](https://github.com/user-attachments/assets/8930e34c-c8be-49e9-b79c-55172f2277e2)
![image](https://github.com/user-attachments/assets/a2e249b2-90f0-438f-94b9-5cd748bbeb59)



## 📸 스크린샷

## 💬리뷰 요구사항(선택)
