### PR TITLE
FIX 사이드바 프사적용, 마이페이지 사이즈 변경

### DIFF
--- a/src/components/rootlayout/Sidebar.tsx
+++ b/src/components/rootlayout/Sidebar.tsx
@@ -135,6 +135,7 @@ export default function Sidebar() {
             BackHeight="h-[122px]"
             IconWidth="w-[84px]"
             IconHeight="h-[84px]"
+            userImg={userInfo?.image}
           />
         )}
       </div>

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -10,7 +10,7 @@ export default function MyPage() {
     <>
       {myInfo && (
         <div className="relative flex flex-col items-center">
-          <div className="w-[1600px] flex flex-col gap-[40px] pt-10">
+          <div className="flex flex-col gap-[40px] pt-10">
             <UserCard
               uname={myInfo.fullName}
               followers={myInfo.followers}

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -4,9 +4,9 @@ import { create } from "zustand";
 // UserInfo.d.ts파일에 넣어놨습니다. 확인하시고 주석지워주세요
 interface MyInfo {
   role: string;
-  emailVerified: false;
-  banned: false;
-  isOnline: true;
+  emailVerified: boolean;
+  banned: boolean;
+  isOnline: boolean;
   posts: MyInfoPost[];
   likes: string[];
   comments: string[];


### PR DESCRIPTION
## #️⃣연관된 이슈

> #165 

## 📝작업 내용
사이드바에 프사 적용했고, 마이페이지 유저정보 부분 사이즈 조절했습니다.
MyInfo 타입을 잘못 적은게 있어서 수정했습니다

## 📸 스크린샷
<img width="309" alt="스크린샷 2024-12-13 오후 3 34 15" src="https://github.com/user-attachments/assets/62c5842b-0a95-4f18-85f1-1ceec609bb71" />
<img width="1501" alt="스크린샷 2024-12-13 오후 3 34 36" src="https://github.com/user-attachments/assets/7936f6c1-ea4e-49ee-aea4-3c7c4d0c257c" />
