### PR TITLE
[DESIGN] 사이드바 마이페이지 연결 유저모달 UI 수정 #183

### DIFF
--- a/src/assets/icons/home_icon.svg
+++ b/src/assets/icons/home_icon.svg
@@ -1,0 +1,21 @@
+<svg width="49" height="49" viewBox="0 0 49 49" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_744_2434)">
+<circle cx="23.5" cy="23.5" r="20.5" fill="white"/>
+</g>
+<path d="M14.75 34.0835H32.25" stroke="#265CAC" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.75 34.0835V18.3335M32.25 34.0835V18.3335" stroke="#265CAC" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.833 20.6668L23.4997 11.3335L35.1663 20.6668" stroke="#265CAC" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20.583 34.0835V23.5835H26.4163V34.0835" stroke="#265CAC" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+<defs>
+<filter id="filter0_d_744_2434" x="0" y="0" width="49" height="49" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="1" dy="1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_744_2434"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_744_2434" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/components/FollowButton.tsx
+++ b/src/components/FollowButton.tsx
@@ -12,7 +12,7 @@ export default function FollowButton({
   return (
     <button
       className={twMerge(
-        "bg-[#265CAC] text-white flex justify-center items-center text-sm cursor-pointer",
+        "bg-[#265CAC] hover:bg-[#1e4d8a] text-white flex justify-center items-center text-sm cursor-pointer",
         width,
         height,
         rounded

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -1,6 +1,7 @@
 import { twMerge } from "tailwind-merge";
 import defaultUser from "../assets/defaultUser.svg";
 import profileEdit from "../assets/profile-edit.svg";
+import home from "../assets/icons/home_icon.svg";
 import { useRef, useState } from "react";
 import { updateUserImg } from "../utils/updateUserImg";
 
@@ -13,6 +14,7 @@ export default function UserProfile({
   onClick,
   update,
   userImg,
+  myProfile,
 }: userProfileType) {
   const imgRef = useRef<HTMLInputElement>(null);
 
@@ -61,6 +63,16 @@ export default function UserProfile({
         <img
           className="absolute right-[-10px] bottom-[-10px]"
           src={profileEdit}
+          alt="profile-edit"
+          onClick={onClick}
+        />
+      )}
+
+      {/* 로그인 유저 마이페이지 아이콘 표시 */}
+      {myProfile && (
+        <img
+          className="absolute right-[-10px] bottom-[-10px]"
+          src={home}
           alt="profile-edit"
           onClick={onClick}
         />

--- a/src/components/rootlayout/Sidebar.tsx
+++ b/src/components/rootlayout/Sidebar.tsx
@@ -14,8 +14,11 @@ import right from "../../assets/double-right.svg";
 import user from "../../assets/user_icon.svg";
 import { useAuth } from "../../stores/authStore";
 import CheckDone from "../checkDone/CheckDone";
+import { useNavigate } from "react-router";
 
 export default function Sidebar() {
+  const navigate = useNavigate();
+
   //로그인상태
   const isLoggedIn = useAuth((state) => state.isLoggedIn);
   // 유저정보
@@ -126,12 +129,13 @@ export default function Sidebar() {
         {/* 유저 프로필 */}
         {isToggle && (
           <UserProfile
-            edit
             BackWidth="w-[122px]"
             BackHeight="h-[122px]"
             IconWidth="w-[84px]"
             IconHeight="h-[84px]"
+            onClick={isLoggedIn ? () => navigate("/myprofile") : undefined}
             userImg={userInfo?.image}
+            myProfile={isLoggedIn} //로그인 여부에 따라 홈 아이콘 표시
           />
         )}
       </div>

--- a/src/components/rootlayout/Sidebar.tsx
+++ b/src/components/rootlayout/Sidebar.tsx
@@ -88,7 +88,6 @@ export default function Sidebar() {
       )}
       onClick={(e) => handleBackClick(e)}
     >
-      <div></div>
       {/* 토글 버튼 */}
       <button
         onClick={handleToggleClick}
@@ -167,7 +166,7 @@ export default function Sidebar() {
           <div className="flex justify-center">
             <button
               className={twMerge(
-                "mt-2 self-center w-[243px] h-[50px] bg-[#265CAC] rounded-[20px] text-lg text-white font-bold relative",
+                "mt-2 self-center w-[243px] h-[50px] bg-[#265CAC] hover:bg-[#1e4d8a] rounded-[20px] text-lg text-white font-bold relative",
                 !isToggle && "hidden"
               )}
               onClick={(e) => {

--- a/src/components/userlistModal/UserBox.tsx
+++ b/src/components/userlistModal/UserBox.tsx
@@ -32,7 +32,7 @@ export default function UserBox({
   //로그인 여부
   const isLogin = useAuth((state) => state.isLoggedIn);
   return (
-    <div className="w-[320px] h-[75px] bg-[#EFEFEF] flex items-center gap-3 pl-[20px] rounded-[10px] flex-shrink-0">
+    <div className="w-[320px] h-[75px] bg-[#EFEFEF] flex items-center gap-3 px-[20px] rounded-[10px] flex-shrink-0">
       {/* 유저 프로필, 현활 */}
       <div
         className="bg-white w-[48px] h-[48px] flex justify-center items-center rounded-[50%] shadow-inner cursor-pointer relative"
@@ -49,8 +49,8 @@ export default function UserBox({
       </div>
 
       {/* 유저  info*/}
-      <div>
-        <div className="flex gap-3 items-center">
+      <div className="w-full">
+        <div className="flex justify-between items-center">
           <p className="font-semibold text-[18px]">{fullname}</p>
           {isLogin && (
             <FollowButton

--- a/src/types/UserProfile.d.ts
+++ b/src/types/UserProfile.d.ts
@@ -7,4 +7,5 @@ interface userProfileType {
   onClick?: () => void;
   update?: boolean;
   userImg?: string;
+  myProfile?: boolean;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#183 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
유저 모달 팔로우 버튼 우측 정렬
버튼 호버 추가
사이드바 유저 프로필 홈 아이콘 추가(로그인시 보입니다)
로그인 상태에서 유저 프로필 클릭시 마이페이지로 이동


> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/3ae03814-b870-4f0c-9c84-72db2bed1827)
![image](https://github.com/user-attachments/assets/aac80e87-c4f7-4ded-844b-6033fd292f36)


## 💬리뷰 요구사항(선택)
