### PR TITLE
[FIX] 게시물 내용 수정창 수정

### DIFF
--- a/src/components/PostDetail/PostInfo.tsx
+++ b/src/components/PostDetail/PostInfo.tsx
@@ -14,6 +14,8 @@ interface PostInfoProps {
   channelId: string;
   owner: boolean;
   postID: string;
+  edit: boolean;
+  setEdit: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function PostInfo({
@@ -25,6 +27,8 @@ export default function PostInfo({
   channelId,
   owner,
   postID,
+  edit,
+  setEdit,
 }: PostInfoProps) {
   // 삭제 모달 확인
   const [isOpen, setIsOpen] = useState(false);
@@ -34,7 +38,6 @@ export default function PostInfo({
   const [context, setContext] = useState(desc);
   const [img, setImg] = useState(image);
   const [uploadImg, setUploadImg] = useState<File | null>(null);
-  const [edit, setEdit] = useState(false);
   const textarea = useRef<HTMLTextAreaElement | null>(null);
 
   const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -45,6 +48,7 @@ export default function PostInfo({
     setContext(e.target.value);
   };
 
+  // 게시물 정보 업데이트
   const updateHandler = async () => {
     const formData = new FormData();
     formData.append(
@@ -107,6 +111,8 @@ export default function PostInfo({
     // 어디로 이동할지는 아직 미정입니다. 일단은 메인으로 이동하게 설정하였습니다.
     navigate("/");
   };
+
+  // 삭제 모달 창 떴을 때 스크롤 제한
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = "hidden"; // 스크롤 금지
@@ -117,6 +123,14 @@ export default function PostInfo({
       document.body.style.overflow = ""; // 컴포넌트 언마운트 시 복원
     };
   }, [isOpen]);
+
+  // 수정 버튼 눌렀을 때 높이 조정
+  useEffect(() => {
+    if (textarea.current) {
+      textarea.current.style.height = "auto"; // 높이 초기화
+      textarea.current.style.height = `${textarea.current.scrollHeight}px`; // 내용에 맞게 높이 조정
+    }
+  }, [edit]);
 
   // Date 객체로 변환
   const date = new Date(createdAt);

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -24,6 +24,8 @@ export default function PostDetail() {
   const { post_id } = useParams();
   const loginId = useAuth((state) => state.user);
   const [data, setData] = useState<PostInfo | null>(null);
+  // 편집모드
+  const [edit, setEdit] = useState(false);
 
   const getPostData = async () => {
     try {
@@ -77,25 +79,32 @@ export default function PostDetail() {
           owner={data.userID === loginId?._id}
           channelId={data.channelId}
           postID={data.postID}
+          edit={edit}
+          setEdit={setEdit}
         />
-        <div className="flex justify-between">
-          <div className="w-[360px] border-2 -[64px] flex items-center gap-4 rounded-[8px]">
-            <img src={leftIcon} alt="leftIcon" />
-            <span>이전 포스트</span>
-          </div>
-          <div className="w-[360px] border-2 h-[64px] flex items-center gap-4 justify-end rounded-[8px]">
-            <span>다음 포스트</span>
-            <img src={rightIcon} alt="leftIcon" />
-          </div>
-        </div>
+        {/* 편집모드 일때는 댓글 렌더링 X */}
+        {!edit && (
+          <>
+            <div className="flex justify-between">
+              <div className="w-[360px] border-2 -[64px] flex items-center gap-4 rounded-[8px]">
+                <img src={leftIcon} alt="leftIcon" />
+                <span>이전 포스트</span>
+              </div>
+              <div className="w-[360px] border-2 h-[64px] flex items-center gap-4 justify-end rounded-[8px]">
+                <span>다음 포스트</span>
+                <img src={rightIcon} alt="leftIcon" />
+              </div>
+            </div>
 
-        {/* 댓글 섹션 */}
-        <CommentSec
-          likes={data.likes}
-          // comments={data.comments}
-          //포스트 아이디
-          postId={post_id}
-        />
+            {/* 댓글 섹션 */}
+            <CommentSec
+              likes={data.likes}
+              // comments={data.comments}
+              //포스트 아이디
+              postId={post_id}
+            />
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

> #197 

## 📝작업 내용

> 수정 버튼 눌렀을 때 게시물 내용이 3줄 이상일 때 2줄만 뜨던 오류 해결하였습니다.
또한 수정 버튼을 눌렀을 때, 밑에 댓글 작성과 댓글 내용을 안보이게 설정하였습니다.
![image](https://github.com/user-attachments/assets/765f0c5a-ba12-4f51-8be6-f103f319f3da)


## 📸 스크린샷

## 💬리뷰 요구사항(선택)
