### PR TITLE
[FEAT] 게시판상단 채널명 표시

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,9 @@ export default function App() {
 
           {/* 오운완 페이지 */}
           <Route path="/records/:post_id" element={<PostDetail />} />
+          <Route path="/protein/:post_id" element={<PostDetail />} />
+          <Route path="/routine/:post_id" element={<PostDetail />} />
+          <Route path="/gymreview/:post_id" element={<PostDetail />} />
 
           <Route path="/about" element={<About />} />
           <Route path="/user/:user_id" element={<User />} />

--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -3,6 +3,7 @@ import likeIcon from "../assets/like_icon.svg";
 import chatIcon from "../assets/chat_icon.svg";
 import UserProfile from "./UserProfile";
 import { useNavigate } from "react-router";
+import { channelMapping } from "../constants/channel";
 
 export default function ImageCard({
   image,
@@ -14,6 +15,7 @@ export default function ImageCard({
   fullName,
   userImg, // 마이페이지, 로그인 한 유저의 사진
   _id: post_id,
+  channel,
 }: PostType & MyInfo) {
   const navigate = useNavigate();
   const update = new Date(createdAt);
@@ -40,13 +42,17 @@ export default function ImageCard({
     postTitle = title;
   }
 
+  const channelName = Object.keys(channelMapping).find(
+    (key) => channelMapping[key] === channel?._id
+  );
+
   return (
     <div className="flex flex-col items-center gap-3">
       {/* 썸네일 */}
       <div
         className="group relative w-[250px] h-[250px] bg-cover bg-center rounded-2xl shadow-lg cursor-pointer"
         style={{ backgroundImage: `url(${image || thumbnail})` }}
-        onClick={() => navigate(`/records/${post_id}`)}
+        onClick={() => navigate(`/${channelName}/${post_id}`)}
       >
         {/* Hover */}
         <div className="absolute inset-0 flex flex-col items-center justify-center text-white transition-opacity duration-300 bg-black bg-opacity-50 rounded-lg opacity-0 group-hover:opacity-100">

--- a/src/components/PostDetail/PostInfo.tsx
+++ b/src/components/PostDetail/PostInfo.tsx
@@ -4,6 +4,7 @@ import { updatePost } from "../../utils/updatePost";
 import { deletePost } from "../../utils/api/deletePosts";
 import DeleteConfirm from "../modal/DeleteConfirm";
 import { useNavigate } from "react-router";
+import { channelMapping } from "../../constants/channel";
 
 interface PostInfoProps {
   title: string;
@@ -138,11 +139,23 @@ export default function PostInfo({
   const formattedDate = `${date.getFullYear()}.${(date.getMonth() + 1)
     .toString()
     .padStart(2, "0")}.${date.getDate().toString().padStart(2, "0")}`;
+
+  // 게시판 이름
+
+  const channel = Object.keys(channelMapping).find(
+    (key) => channelMapping[key] === channelId
+  );
+
+  const channelName: { [key: string]: string } = {
+    records: "오운완 인증",
+    protein: "프로틴 추천",
+    routine: "루틴 공유",
+    gymreview: "헬스장 리뷰",
+  };
+
   return (
     <>
-      <div className="text-sm ">
-        게시판이름 (넣을려고했는데 어떻게 처리할지고 고민중)
-      </div>
+      <div className="text-sm ">{channel ? channelName[channel] : null} </div>
       {edit ? (
         <input
           className="py-3 mb-4 text-4xl focus:outline-none border w-full border-[#d3d3d3d3]"

--- a/src/components/Review.tsx
+++ b/src/components/Review.tsx
@@ -45,7 +45,7 @@ export default function Review({
   return (
     <div
       className="w-[900px] h-[315px] mb-[109px] relative flex flex-row"
-      onClick={() => navigate(`/records/${post_id}`)}
+      onClick={() => navigate(`/gymreview/${post_id}`)}
     >
       {/* 썸네일 */}
       <div>

--- a/src/constants/channel.ts
+++ b/src/constants/channel.ts
@@ -1,1 +1,10 @@
-export const channelMapping = { records: "6757a3a7ce18fa02ded5c758" };
+interface ChannelMappingType {
+  [key: string]: string;
+}
+
+export const channelMapping: ChannelMappingType = {
+  records: "6757a3a7ce18fa02ded5c758",
+  protein: "6758f6bf5f86e71ae5eb9b6c",
+  routine: "6758f7305f86e71ae5eb9b82",
+  gymreview: "6758f75b5f86e71ae5eb9bae",
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #196 

## 📝작업 내용
상세게시글 상단에 채널명 표시했습니다.

상세 게시글 라우팅 수정했습니다. 각 채널에 맞는 라우트로 접근합니다 ex) /protein/:post_Id

## 📸 스크린샷
<img width="865" alt="스크린샷 2024-12-15 오후 10 23 23" src="https://github.com/user-attachments/assets/fd9a1d46-d1a2-4486-9602-07dcde5a68ea" />

<img width="385" alt="스크린샷 2024-12-15 오후 10 23 55" src="https://github.com/user-attachments/assets/ddbb8bd5-c8ed-40ff-97b9-1812833079b9" />

