### PR TITLE
[FIX] 상세게시글 유저 프로필사진 수정

### DIFF
--- a/src/components/PostDetail/PostInfo.tsx
+++ b/src/components/PostDetail/PostInfo.tsx
@@ -16,6 +16,7 @@ interface PostInfoProps {
   owner: boolean;
   postID: string;
   edit: boolean;
+  userImg: string;
   setEdit: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
@@ -29,6 +30,7 @@ export default function PostInfo({
   owner,
   postID,
   edit,
+  userImg,
   setEdit,
 }: PostInfoProps) {
   // 삭제 모달 확인
@@ -168,7 +170,11 @@ export default function PostInfo({
       <div className="flex items-center justify-between">
         {/* 왼쪽 프로필 */}
         <div className="flex gap-[10px] items-center">
-          <UserProfile BackWidth="w-[36px]" BackHeight="h-[36px]" />
+          <UserProfile
+            BackWidth="w-[36px]"
+            BackHeight="h-[36px]"
+            userImg={userImg}
+          />
           <div>
             <p className="text-[13px] mb-[6px] font-bold">{fullName}</p>
             <p className="text-xs">{formattedDate}</p>

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -18,6 +18,7 @@ interface PostInfo {
   likes: LikeType[];
   channelId: string;
   postID: string;
+  userImg: string;
 }
 
 export default function PostDetail() {
@@ -33,7 +34,7 @@ export default function PostDetail() {
       const { data } = await api.get(`/posts/${post_id}`);
       console.log(data);
       const {
-        author: { fullName, _id: userID },
+        author: { fullName, _id: userID, image: userImg },
         channel: { _id: channelId },
         // comments,
         title,
@@ -54,6 +55,7 @@ export default function PostDetail() {
         likes,
         channelId,
         postID,
+        userImg,
       });
     } catch (error) {
       console.error("Error fetching post data: ", error);
@@ -81,6 +83,7 @@ export default function PostDetail() {
           postID={data.postID}
           edit={edit}
           setEdit={setEdit}
+          userImg={data.userImg}
         />
         {/* 편집모드 일때는 댓글 렌더링 X */}
         {!edit && (


### PR DESCRIPTION
## #️⃣연관된 이슈
#204 

## 📝작업 내용
기존에 상세 게시글에서 기본 프로필사진으로 나오는 것을 유저 프로필사진으로 변경하였습니다

## 📸 스크린샷
<img width="352" alt="스크린샷 2024-12-16 오전 9 46 08" src="https://github.com/user-attachments/assets/350cc42c-69a9-4604-b90c-96a7eeff9fd1" />

