### PR TITLE
[FEAT] 이전/다음 페이지 이동 #166

### DIFF
--- a/src/assets/icons/double-left_blue.svg
+++ b/src/assets/icons/double-left_blue.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 22L2 12L12 2M22 22L12 12L22 2" stroke="#265CAC" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/double-right_blue.svg
+++ b/src/assets/icons/double-right_blue.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 22L22 12L12 2M2 22L12 12L2 2" stroke="#265CAC" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/PostDetail/PostInfo.tsx
+++ b/src/components/PostDetail/PostInfo.tsx
@@ -5,6 +5,7 @@ import { deletePost } from "../../utils/api/deletePosts";
 import DeleteConfirm from "../modal/DeleteConfirm";
 import { useNavigate } from "react-router";
 import { channelMapping } from "../../constants/channel";
+import thumbnail from "../../assets/images/feed_thumbnail.jpg";
 
 interface PostInfoProps {
   title: string;
@@ -205,7 +206,11 @@ export default function PostInfo({
               />
               <label htmlFor="uploadImg" className="cursor-pointer">
                 <div className="relative group">
-                  <img src={img} alt="업로드이미지" className="" />
+                  <img
+                    src={img || thumbnail}
+                    alt={img ? "업로드된 이미지" : "기본 썸네일"}
+                    className=""
+                  />
                   <div className="absolute flex flex-col justify-center items-center inset-0 text-[20px] text-white bg-black bg-opacity-50 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                     <span>
                       수정하려면{" "}
@@ -225,7 +230,10 @@ export default function PostInfo({
               </label>
             </>
           ) : (
-            <img src={img} alt="업로드이미지" />
+            <img
+              src={img || thumbnail}
+              alt={img ? "업로드된 이미지" : "기본 썸네일"}
+            />
           )}
         </div>
         {edit ? (


### PR DESCRIPTION
## #️⃣연관된 이슈

> #155 

## 📝작업 내용

> 이전 페이지 및 다음 페이지 이동 기능 구현
> 등록된 이미지 없을 시 기본 썸네일로 표현되게끔 코드 수

⚠️버그 발생
- 포스트 목록에 비정상적인 포스트가 존재하여 페이지 이동 시 화면에 오류가 발생
> 포스트 목록을 불러오는 것이 아닌 존재하는 포스트의 아이디로 새로운 배열을 만들어 버그 해결

## 📸 스크린샷
- 제일 첫 포스트
![image](https://github.com/user-attachments/assets/f766caed-b44d-4c82-8f64-cc9c5e7f08ae)
- 중간 포스트
![image](https://github.com/user-attachments/assets/ba5f34ed-5a24-4852-8a61-01ed207dea50)
- 마지막 포스트
![image](https://github.com/user-attachments/assets/87205755-4672-4afd-a2e0-1b7dc6c2f274)

## 💬리뷰 요구사항(선택)
