### PR TITLE
[FEAT]202_comment/follow_NotificationCreate

### DIFF
--- a/src/assets/icons/Comment_Icon.svg
+++ b/src/assets/icons/Comment_Icon.svg
@@ -1,0 +1,9 @@
+<svg width="61" height="61" viewBox="0 0 61 61" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<rect width="61" height="61" fill="url(#pattern0_843_2724)"/>
+<defs>
+<pattern id="pattern0_843_2724" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_843_2724" transform="scale(0.01)"/>
+</pattern>
+<image id="image0_843_2724" width="100" height="100" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAACXBIWXMAAAsTAAALEwEAmpwYAAACQElEQVR4nO3csW7UQBCA4S1AAh6AAilNngEaGvIcNKRKT42y0yPxAFeFDilKdiJeIEqThmegoUsLmrUESEanSFTostw5nrH9f5Lrs+fP3vruFKcEAAAAAAAAAAA8iHYHonbEYTvMoDsYLEgudiJae4669QzWMySIxvkjIoj6RyCI+g+eIOo/7DhBin3Pal857O8M1jNxCzLoi8xEHmNWBGlHkGAIEgxBgiFIMAQJhiDBECQYggRDkGAIEswkgmStqzkcaYRZpTFexPurbxnoGGNWTQhSCSIBVgQrRP2HTpAAg5alBfG+O8rcZS1XnsIKWZJMkFgIEgxBgplEEDnr9r2Ot6f94zSiaQRx/fzQDfd/GQ0IogRhhWzAClFWCCtkA1aIskK47Z36ClmSTJBYCBIMQYIhSDAECYYgwRAkGIIEQ5BgCBKMaxBRu97pKXMX9qz1HETry4k80e7aMcg4P6/K7YX+9P0peLdjFkHkpH8kah+9h0mQlNI7rXu51C/egyRISum41FdZ6433EAmSbveLXOyX9wBDBxG197s8Na5lD5HP/ZOs9unOC1PrpvgEu/UMUxR3BWneL4p9Oz63F97XM3mbgrTuF7nYlZz/eOp9LbOwYdCnova74W3qg1z2D7yvYza23gjVOtHu0Pv8Z2erIIX9IkyQzH5xv/7vbaqujlb9w3s+pWVjvwimZb+QC3vufZ6LwX4RDPtFMP/8PqrUN97ntVjsF8Hw+SIYPl8EI1pfe58DAAAAAAAAgDSoP7BEOUWFkHy7AAAAAElFTkSuQmCC"/>
+</defs>
+</svg>

--- a/src/components/NotificationBox.tsx
+++ b/src/components/NotificationBox.tsx
@@ -32,18 +32,7 @@ export default function NotificationBox({
           <article className="text-xs font-bold">
             {fullname} 님께서 회원님을 팔로우합니다!
           </article>
-          <div className="flex items-center w-full mt-1">
-            <button
-              className="w-[60px] h-[30px] rounded-[10px] bg-blue-500 
-        text-white flex justify-center items-center cursor-pointer font-bold`,
-        "
-              onClick={() => {
-                alert("팔로우 기능 구현 예정!");
-              }}
-            >
-              Follow
-            </button>
-          </div>
+          <div className="flex items-center w-full mt-1"></div>
         </div>
       )}
       {notificationType === "comment" && (

--- a/src/components/PostDetail/CommentSec.tsx
+++ b/src/components/PostDetail/CommentSec.tsx
@@ -10,10 +10,12 @@ export default function CommentSec({
   likes,
   // comments,
   postId,
+  postAuthorId,
 }: {
   likes: LikeType[];
   // comments: CommentType[];
   postId: string | undefined;
+  postAuthorId: string;
 }) {
   const [commentList, setCommentList] = useState<Comment[]>([]); //댓글 목록
   const [isLoading, setIsLoading] = useState(false); // 로딩 상태
@@ -50,6 +52,7 @@ export default function CommentSec({
     const option = {
       comment,
       postId,
+      postAuthorId,
     };
 
     try {

--- a/src/components/notification/Notification.tsx
+++ b/src/components/notification/Notification.tsx
@@ -1,19 +1,59 @@
 import ButtonComponent from "../ButtonComponent";
 import likeIcon from "../../assets/noti_like_Icon.svg";
 import followIcon from "../../assets/noti_follow_Icon.svg";
-import messageIcon from "../../assets/noti_message_icon.svg";
+import commentIcon from "../../assets/icons/Comment_Icon.svg";
 import NotificationBox from "../NotificationBox";
+import { api } from "../../api/axios";
+import { AxiosError } from "axios";
+import { useState } from "react";
 
 interface notificationProps {
   closeNoti: () => void;
+  notificationArray?: any;
   //   notification: [number, number, number];
 }
 
 // 여기에 좋아요, 팔로우, 메세지 갯수 받아서 사용
 const notification = [100, 1, 17];
 
+// const [notificationArrayAsync, setNotificationArrayAsync] = useState({
+//   fullname: "",
+//   image: "",
+//   type: "",
+//   email: "",
+// });
+
+// const notificationChangeHandler = (data: object) => {
+//   setNotificationArrayAsync({
+//     fullname: "",
+//     image: "",
+//     type: "",
+//     email: "",
+//   });
+// };
+
 // API보고 notificationArray 받아서 처리하자
-export default function Notification({ closeNoti }: notificationProps) {
+export default function Notification({
+  closeNoti,
+  notificationArray,
+}: notificationProps) {
+  const notificationSeen = async () => {
+    try {
+      const { status, data } = await api.put("/notifications/seen");
+      console.log(data);
+      showNotiListHandler();
+    } catch (error) {
+      console.log(error);
+      if ((error as AxiosError).response?.status === 400) {
+        alert("아이디나 비밀번호가 틀립니다.");
+      }
+    }
+  };
+  const [showNotiList, setShowNotiList] = useState(true);
+  const showNotiListHandler = () => {
+    setShowNotiList(false);
+    console.log(showNotiList);
+  };
   return (
     <div>
       <div className="absolute z-10 top-[32px] right-[80px] mt-2 w-[280px]  p-[18px] rounded-[10px] ">
@@ -29,10 +69,10 @@ export default function Notification({ closeNoti }: notificationProps) {
             <div className="sticky top-0 bg-white z-10">
               <div className="flex justify-between items-center w-full px-4 relative ">
                 <img
-                  src={messageIcon}
+                  src={commentIcon}
                   className="relative"
                   onClick={() => {
-                    console.log("message");
+                    console.log("comment");
                   }}
                 />
                 {notification[2] != 0 && (
@@ -71,38 +111,18 @@ export default function Notification({ closeNoti }: notificationProps) {
             {/* 여기까지 */}
             {/* 바디부분 길이 초과시 스크롤나게 */}
             <div className="w-full overflow-y-auto max-h-[330px] scrollbar-none">
-              <div className="">
-                <NotificationBox
-                  fullname="정완"
-                  userid="wjw1469"
-                  notificationType="comment"
-                />
-                <NotificationBox
-                  fullname="수영"
-                  userid="wjw1469"
-                  notificationType="comment"
-                />
-                <NotificationBox
-                  fullname="규혁"
-                  userid="wjw1469"
-                  notificationType="follow"
-                />
-                <NotificationBox
-                  fullname="윤지"
-                  userid="wjw1469"
-                  notificationType="follow"
-                />
-                <NotificationBox
-                  fullname="송원"
-                  userid="wjw1469"
-                  notificationType="message"
-                />
-                <NotificationBox
-                  fullname="정인"
-                  userid="wjw1469"
-                  notificationType="follow"
-                />
-              </div>
+              {notificationArray.length && showNotiList ? (
+                notificationArray.map((notification) => (
+                  <NotificationBox
+                    fullname={notification.author.fullName}
+                    userid={notification.author.email}
+                    image={""}
+                    notificationType={"follow"}
+                  ></NotificationBox>
+                ))
+              ) : (
+                <p>알림이 없습니다</p>
+              )}
             </div>
             {/* 여기까지 */}
             {/* 푸터부분 */}
@@ -113,7 +133,7 @@ export default function Notification({ closeNoti }: notificationProps) {
                   textcolor="text-[#265CAC]"
                   onClick={() => {
                     // Todo 모두읽기 기능 구현
-                    console.log(1111);
+                    notificationSeen();
                   }}
                 >
                   {"모두읽기"}

--- a/src/components/rootlayout/Header.tsx
+++ b/src/components/rootlayout/Header.tsx
@@ -31,13 +31,13 @@ export default function Header({
   const logout = useAuth((state) => state.logout);
   const setUser = useAuth((state) => state.setUser);
   const userInfo = useAuth((state) => state.user);
-
+  const notificationArray = userInfo?.notifications;
   // 테스트용 빠른 로그인입니다 귀찮으신분 자기 ID 비번 적어서 사용하세요
   const fastlogin = async () => {
     try {
       const { status, data } = await api.post("login", {
-        email: "wjw1469@gmail.com",
-        password: "asdf1234",
+        email: "test2@test.com",
+        password: "1234",
       });
       setToken(data.token);
       login();
@@ -119,7 +119,12 @@ export default function Header({
               <div className="w-3 h-3 rounded-[50%] bg-red-500 absolute bottom-0 right-0"></div>
             )}
             {/* 알림창 보여줘야한다면 처리 */}
-            {showNoti && <Notification closeNoti={showNotiHandler} />}
+            {showNoti && (
+              <Notification
+                closeNoti={showNotiHandler}
+                notificationArray={notificationArray}
+              />
+            )}
           </div>
 
           <UserProfile

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -95,13 +95,13 @@ export default function PostDetail() {
                 <img src={rightIcon} alt="leftIcon" />
               </div>
             </div>
-
             {/* 댓글 섹션 */}
             <CommentSec
               likes={data.likes}
               // comments={data.comments}
               //포스트 아이디
               postId={post_id}
+              postAuthorId={data.userID}
             />
           </>
         )}

--- a/src/utils/api/createNotification.ts
+++ b/src/utils/api/createNotification.ts
@@ -1,0 +1,19 @@
+import { api } from "../../api/axios";
+
+export const createNotification = async (
+  notificationType: string,
+  notificationTypeId: string,
+  userId: string,
+  postId?: string
+) => {
+  try {
+    await api.post("/notifications/create", {
+      notificationType,
+      notificationTypeId,
+      userId,
+      postId,
+    });
+  } catch (error) {
+    console.error("글 삭제 도중 오류가 발생했습니다.", error);
+  }
+};

--- a/src/utils/commentFn.ts
+++ b/src/utils/commentFn.ts
@@ -1,15 +1,22 @@
 import { api } from "../api/axios";
+import { createNotification } from "../utils/api/createNotification";
 
 interface newCommentFnType {
   comment: string;
   postId: string | undefined;
+  postAuthorId: string;
 }
 
 export const newCommentFn = async (option: newCommentFnType) => {
   try {
     const { data } = await api.post("/comments/create", option);
     // 응답 처리
-    // console.log("댓글 등록 성공:", data);
+    const rtype = "COMMENT";
+    const commentUserId = data.id;
+    const postUserId = option.postAuthorId;
+    const postId = data.post;
+
+    await createNotification(rtype, commentUserId, postUserId, postId);
     return data;
   } catch (err) {
     console.error(err);

--- a/src/utils/postLikeFn.ts
+++ b/src/utils/postLikeFn.ts
@@ -1,10 +1,15 @@
 import { api } from "../api/axios";
+import { createNotification } from "./api/createNotification";
 
 export const addPostLike = async (postId: string) => {
   try {
     const { data } = await api.post("/likes/create", { postId });
 
-    // console.log("좋아요 등록:", data);
+    const rtype = "LIKE";
+    const likeId = data._id;
+
+    // Todo - 여기서도 글쓴이 ID값을 받아올 방법 찾아서 넣어주기
+    await createNotification(rtype, likeId, "675fcec7f707bd088eee7545", postId);
     return data;
   } catch (err) {
     console.log(err);


### PR DESCRIPTION
## #️⃣연관된 이슈

#202 

## 📝작업 내용

알림창에서 메세지 -> 댓글로 이모티콘 추가 

댓글작성/ 팔로우시에 API로 알람을 생성해야 하기 때문에 
댓글작성/ 팔로우 성공시에 해당하는 API를 발생시키도록 추가  (../utils/api/createNotification.ts) 참조바람
댓글작성/팔로우시에 API의 Parameter로 사용할 글쓴이의 ID객체를 가져와야 하기 때문에 
이전 단계에서 인자로 추가하였으며, 
팔로우에도 동일하게 처리해야 하는 것으로 보임 (확인요망)



## 📸 스크린샷

![image](https://github.com/user-attachments/assets/e04367c7-e6af-429e-b1fa-cf26f54c6d72)


## 💬리뷰 요구사항(선택)

Comment작성시에 글쓴이의 ID값을 가져올 방법이없어서 인자로 추가하였습니다. 
담당자는 해당 소스에 문제없을지 확인 부탁드립니다
