### PR TITLE
[FEAT] 상세게시글 상단 게시판이름 클릭 시 해당 게시판으로 이동 구현

### DIFF
--- a/src/components/PostDetail/PostInfo.tsx
+++ b/src/components/PostDetail/PostInfo.tsx
@@ -158,7 +158,12 @@ export default function PostInfo({
 
   return (
     <>
-      <div className="text-sm ">{channel ? channelName[channel] : null} </div>
+      <div
+        className="text-sm hover:underline cursor-pointer"
+        onClick={() => navigate(`/${channel}`)}
+      >
+        {channel ? channelName[channel] : null}
+      </div>
       {edit ? (
         <input
           className="py-3 mb-4 text-4xl focus:outline-none border w-full border-[#d3d3d3d3]"


### PR DESCRIPTION
## #️⃣연관된 이슈

> #240 

## 📝작업 내용
상세게시글 상단 게시판이름 클릭 시 해당 게시판으로 이동 구현헀습니다.

게시판이름에 호버 시 underline 설정했고 cursor-pointer로 설정했습니다 이 부분에 의견있으시면 말씀해주세용
클릭하면 해당 게시판으로 이동합니다
현재 오운완 페이지 라우터를 고민 중에 있습니다 오운완 상세 게시글에서는 클릭 할 때 오류납니다. 메인페이지 라우터가 정해지면 추후 수정예정입니다.

## 📸 스크린샷
<img width="282" alt="스크린샷 2024-12-17 오전 1 15 45" src="https://github.com/user-attachments/assets/ed1524b3-6730-4ec6-b06a-e923d1738b97" />

