### PR TITLE
[FEAT] 다크모드 임시 구현

### DIFF
--- a/src/components/button/ModeChange.tsx
+++ b/src/components/button/ModeChange.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { twMerge } from "tailwind-merge";
 import { usesidebarToggleStore } from "../../stores/sideberToggleStore";
 import horizontalAfternoon from "../../assets/horizontalAfternoon.svg";
@@ -9,10 +9,15 @@ import sun from "../../assets/sun.svg";
 import moon from "../../assets/moon.svg";
 import DeleteConfirm from "../modal/DeleteConfirm";
 import innercircle from "../../assets/innercircle.svg";
+import { useDarkModeStore } from "../../stores/darkModeStore";
 
 export default function ModeChange() {
   const [isClicked, setIsClicked] = useState(false);
   const isToggle = usesidebarToggleStore((state) => state.isToggle);
+
+  // 다크모드
+  const isDark = useDarkModeStore((state) => state.isDark);
+  const toggleDarkMode = useDarkModeStore((state) => state.toggleDarkMode);
 
   // /* 삭제 모달 테스트용 코드 */
   // const [isModalOpen, setIsModalOpen] = useState(false);
@@ -34,8 +39,17 @@ export default function ModeChange() {
   // /* 테스트용 코드 여기까지 */
 
   const handleClick = () => {
-    setIsClicked((click) => !click);
+    // setIsClicked((click) => !click);
+    toggleDarkMode();
   };
+
+  useEffect(() => {
+    if (isDark) {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+  });
 
   return (
     <div className="flex items-center justify-center">
@@ -46,7 +60,7 @@ export default function ModeChange() {
           "relative w-[63px] h-[30px] rounded-full text-white font-bold text-[16px] overflow-hidden group shadow-inner"
         )}
         style={{
-          backgroundImage: isClicked
+          backgroundImage: isDark
             ? `url(${horizontalNight})`
             : `url(${horizontalAfternoon})`,
           backgroundSize: "cover",
@@ -54,11 +68,11 @@ export default function ModeChange() {
         }}
       >
         <img
-          src={isClicked ? moon : sun}
+          src={isDark ? moon : sun}
           alt="circleHorizontal"
           className={twMerge(
             `absolute w-[18px] h-[18x] rounded-full transition-all duration-300 ease-in-out translate-y-[5.5px] ${
-              isClicked ? "translate-x-[8px]" : "translate-x-[34px]"
+              isDark ? "translate-x-[8px]" : "translate-x-[34px]"
             } mt-[-15px] top-[50%] group-hover:scale-110`
           )}
         />
@@ -67,7 +81,7 @@ export default function ModeChange() {
           alt="innercircle"
           className={twMerge(
             `absolute w-[25px] h-[25x] rounded-full transition-all duration-300 ease-in-out translate-y-[3.3px] ${
-              isClicked ? "translate-x-[36px]" : "translate-x-[2px]"
+              isDark ? "translate-x-[36px]" : "translate-x-[2px]"
             } mt-[-15px] top-[50%]`
           )}
         />

--- a/src/components/userlistModal/UserListModal.tsx
+++ b/src/components/userlistModal/UserListModal.tsx
@@ -9,6 +9,7 @@ import { usesidebarToggleStore } from "../../stores/sideberToggleStore";
 import Lottie from "react-lottie-player";
 import lottieJson from "../../assets/lottie/loading-b.json";
 import { twMerge } from "tailwind-merge";
+import { useDarkModeStore } from "../../stores/darkModeStore";
 
 interface UserListModalType {
   handleBackClick: (e: React.MouseEvent<HTMLDivElement>) => void;
@@ -19,6 +20,9 @@ export default function UserListModal({
   handleBackClick,
   setIsOpen,
 }: UserListModalType) {
+  // 다크모드
+  const isDark = useDarkModeStore((state) => state.isDark);
+
   // 토글 상태
   const isToggle = usesidebarToggleStore((state) => state.isToggle);
 
@@ -94,7 +98,7 @@ export default function UserListModal({
         isToggle ? `left-[290px]` : "left-[90px]"
       }
       before:modal-before  scrollbar-none flex flex-col justify-start items-center
-      gap-10 py-8 z-30`}
+      gap-10 py-8 z-30 dark:bg-black`}
         onClick={(e) => {
           e.stopPropagation();
         }}

--- a/src/stores/darkModeStore.ts
+++ b/src/stores/darkModeStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface DarkModeStore {
+  isDark: boolean;
+  toggleDarkMode: () => void;
+}
+
+export const useDarkModeStore = create<DarkModeStore>((set) => ({
+  isDark: false,
+  toggleDarkMode: () => set((state) => ({ isDark: !state.isDark })),
+}));

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: "class",
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #252 

## 📝작업 내용
다크모드 설정 -> 전역으로 관리

className에 dark:bg-black 이런 식으로 작성하면 다크모드 적용됩니다.

## 📸 스크린샷
<img width="1169" alt="스크린샷 2024-12-17 오후 2 11 53" src="https://github.com/user-attachments/assets/c5482358-e04f-4af2-a74d-dc10755c493f" />


