### PR TITLE
[DESIGN] 마이페이지 / 유저 페이지의 하단 padding 값 추가

### DIFF
--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -24,8 +24,8 @@ export default function MyPage() {
   return (
     <>
       {myInfo && (
-        <div className="relative flex flex-col items-center">
-          <div className="flex flex-col gap-[40px] pt-10">
+        <div className="relative flex flex-col items-center py-8">
+          <div className="flex flex-col gap-[40px]">
             <UserCard
               uname={myInfo.fullName!}
               followers={myInfo.followers}
@@ -38,7 +38,7 @@ export default function MyPage() {
               update={true}
               userImg={myInfo.image}
             />
-            <div className="flex xl:flex-row flex-col items-center w-full gap-4">
+            <div className="flex flex-col items-center w-full gap-4 xl:flex-row">
               <CustomCalendar />
               <CheckDone bg="bg-[#F7FAFF]" />
             </div>

--- a/src/pages/User.tsx
+++ b/src/pages/User.tsx
@@ -23,8 +23,8 @@ export default function User() {
   return (
     <>
       {user && (
-        <div className="flex flex-col items-center">
-          <div className=" flex flex-col gap-[40px] pt-10">
+        <div className="flex flex-col items-center py-8">
+          <div className=" flex flex-col gap-[40px]">
             <UserInfoCard
               uname={user.fullName}
               userId={user._id}
@@ -61,7 +61,7 @@ export default function User() {
                   </div>
                 ) : (
                   <div className="w-[814px]">
-                    <p className="text-gray-500 text-center">
+                    <p className="text-center text-gray-500">
                       게시물이 없습니다.
                     </p>
                   </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 마이페이지 / 유저 페이지의 하단 padding 값 추가하였습니다.
하단 공간이 부족헤서 padding 추가하였습니다. 하단에 32px padding 주었습니다.
![image](https://github.com/user-attachments/assets/9ef2e825-bb1a-4e68-8eb6-dbb8ca18818b)
![image](https://github.com/user-attachments/assets/b7150458-60ba-43aa-a947-95bf78ac5ce0)


## 📸 스크린샷

## 💬리뷰 요구사항(선택)
