### PR TITLE
[FIX] 게시물 삭제 시 해당채널로 이동

### DIFF
--- a/src/components/PostDetail/PostInfo.tsx
+++ b/src/components/PostDetail/PostInfo.tsx
@@ -131,7 +131,7 @@ export default function PostInfo({
     setIsOpen(!isOpen);
     alert("삭제되었습니다");
     // 어디로 이동할지는 아직 미정입니다. 일단은 메인으로 이동하게 설정하였습니다.
-    navigate("/");
+    navigate(`/${channel}`);
   };
 
   // 모달 창 떴을 때 스크롤 제한(삭제 모달, 수정 모달)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #293 

## 📝작업 내용
게시물 삭제 시 해당 채널에 맞게 이동합니다

## 📸 스크린샷

https://github.com/user-attachments/assets/1dffb05e-746f-4268-ad27-105185043981


