### PR TITLE
[FIX] 유저페이지 타입오류수정

### DIFF
--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -52,9 +52,13 @@ export default function ImageCard({
     navigate(`/user/${userid}`);
   };
 
-  const channelName = Object.keys(channelMapping).find(
-    (key) => channelMapping[key] === channel?._id
-  );
+  const channelName = Object.keys(channelMapping).find((key) => {
+    if (typeof channel === "string") {
+      return channelMapping[key] === channel;
+    } else {
+      return channelMapping[key] === channel?._id;
+    }
+  });
 
   // 본인 좋아요 확인
   const checkIsLiked = likes.some((like) => like.user === myInfo?._id);

--- a/src/pages/User.tsx
+++ b/src/pages/User.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { api } from "../api/axios";
 import UserInfoCard from "../components/User/UserInfoCard";
 import MyImageCard from "../components/MyImageCard";
+import ImageCard from "../components/ImageCard";
 
 export default function User() {
   const { user_id } = useParams();
@@ -43,7 +44,7 @@ export default function User() {
                     <div className="flex items-center justify-center">
                       <div className="grid gap-8 2xl:grid-cols-4 xl:grid-cols-3 lg:grid-cols-2">
                         {user.posts?.map((post) => (
-                          <MyImageCard
+                          <ImageCard
                             key={post._id}
                             image={post.image}
                             comments={post.comments}

--- a/src/types/Post.d.ts
+++ b/src/types/Post.d.ts
@@ -12,16 +12,18 @@ interface PostType {
   title: string;
   image: string;
   imagePublicId?: string;
-  channel?: {
-    authRequired: boolean;
-    posts: string[];
-    _id: string;
-    name: string;
-    description: string;
-    createdAt: string;
-    updatedAt: string;
-    __v: number;
-  };
+  channel?:
+    | {
+        authRequired: boolean;
+        posts: string[];
+        _id: string;
+        name: string;
+        description: string;
+        createdAt: string;
+        updatedAt: string;
+        __v: number;
+      }
+    | string;
   author?: {
     role: string;
     emailVerified: boolean;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #298 

## 📝작업 내용
유저페이지 타입오류 수정했습니다.
MYImageCard 컴포넌트에서 ImageCard 컴포넌트로 변경했습니다.

imageCard 컴포넌트 부분 채널이름 가져오는 로직 살짝 수정했습니다.

## 📸 스크린샷
<img width="480" alt="스크린샷 2024-12-18 오후 12 17 42" src="https://github.com/user-attachments/assets/061fbad6-ea89-42dc-9b26-fa777906d9b4" />

