### PR TITLE
[FEAT] 채널페이지 다크모드 구현

### DIFF
--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -107,11 +107,11 @@ export default function ImageCard({
               userImg={userImg ? userImg : author?.image}
             />
           </div>
-          <div className="text-base font-medium">
+          <div className="text-base font-medium dark:text-[#fff]">
             {author ? author.fullName : fullName}
           </div>
         </div>
-        <div className="text-sm font-light">{date}</div>
+        <div className="text-sm font-light dark:text-white">{date}</div>
       </div>
     </div>
   );

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,5 +1,7 @@
 import { twMerge } from "tailwind-merge";
 import searchIcon from "../assets/searchIcon.svg";
+import darkSearchIcon from "../assets/darkicons/darkSearchIcon.svg";
+import { useDarkModeStore } from "../stores/darkModeStore";
 
 export default function SearchBar({
   placeholder,
@@ -12,6 +14,8 @@ export default function SearchBar({
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }) {
+  const isDark = useDarkModeStore((state) => state.isDark);
+
   return (
     <div
       className={twMerge(
@@ -20,13 +24,13 @@ export default function SearchBar({
       )}
     >
       <input
-        className="w-full outline-none"
+        className="w-full outline-none dark:bg-lightBlackDark dark:text-[#fff]"
         type="text"
         placeholder={placeholder}
         value={value}
         onChange={onChange}
       />
-      <img src={searchIcon} alt="검색 아이콘" />
+      <img src={!isDark ? searchIcon : darkSearchIcon} alt="검색 아이콘" />
     </div>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -131,7 +131,10 @@ export default function Home() {
   }, [searchTerm]);
 
   return (
-    <div className="relative flex flex-col gap-10 py-8">
+    <div
+      className="relative flex flex-col gap-10 py-8 dark:bg-lightBlackDark"
+      style={{ minHeight: "calc(100vh - 70px)" }}
+    >
       {/* 로딩창 */}
       <Loading />
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #289 

## 📝작업 내용
채널페이지 다크모드 구현
다크모드 시 배경이 이미지카드 부분까지만 나와서 HOME 컴포넌트 최소높이값 수정했습니다.

## 📸 스크린샷
<img width="2258" alt="스크린샷 2024-12-18 오후 2 45 00" src="https://github.com/user-attachments/assets/ac3d5f71-bacc-4969-a237-def07e4ea941" />

