### PR TITLE
[FEAT]328_NotificationRefresh_design_imageLink

### DIFF
--- a/src/components/NotificationBox.tsx
+++ b/src/components/NotificationBox.tsx
@@ -1,3 +1,6 @@
+NotificationBox;
+
+import { useNavigate } from "react-router";
 import defaultUserImg from "../assets/defaultUser.svg";
 
 interface NotificationBoxPropsType {
@@ -13,38 +16,42 @@ export default function NotificationBox({
   userid,
   notificationType,
 }: NotificationBoxPropsType) {
+  const navigate = useNavigate();
+
   return (
-    <div className="w-[320px] h-[75px] bg-[#EFEFEF] mt-4 flex items-center gap-3 pl-[20px] rounded-[10px] flex-shrink-0 ">
+    <div className="w-[270px] h-[75px] bg-[#EFEFEF] mt-4 flex items-center gap-3 pl-[20px] rounded-[10px] flex-shrink-0 ">
       {/* 유저 프로필, 현활 */}
       <div
-        className="bg-white w-[48px] h-[48px] flex justify-center items-center rounded-[50%] shadow-inner cursor-pointer relative"
+        className="bg-white w-[46px] h-[46px] flex justify-center items-center rounded-[50%] shadow-inner cursor-pointer relative"
         // onClick={() => handleClick(userid)}
       >
         <img
           src={image ? image : defaultUserImg}
           alt="사용자 프로필 사진"
-          className="w-[35px] h-[35px] rounded-[50%]"
+          className="w-[33px] h-[33px] rounded-[50%]"
+          onClick={() => {
+            navigate(`/user/${userid}`);
+          }}
         />
       </div>
 
       {notificationType === "follow" && (
-        <div className=" w-[220px] h-[50px] items-center bg">
-          <article className="text-xs font-bold">
+        <div className=" w-[220px] h-[50px] flex items-center justify-center">
+          <article className="text-sm font-bold">
             {fullname} 님께서 회원님을 팔로우합니다!
           </article>
-          <div className="flex items-center w-full mt-1"></div>
         </div>
       )}
       {notificationType === "comment" && (
-        <div className="w-[220px] h-[50px] ">
-          <p className="text-xs font-bold">
+        <div className="w-[220px] h-[50px] flex items-center justify-center  ">
+          <p className="text-sm font-bold ">
             {fullname} 님께서 회원님의 글에 댓글을 남겼습니다{" "}
           </p>
         </div>
       )}
       {notificationType === "like" && (
-        <div className=" w-[230px] h-[50px]">
-          <p className="text-xs font-bold ">
+        <div className=" w-[230px] h-[50px] flex items-center justify-center  ">
+          <p className="text-sm font-bold ">
             {fullname} 님께서 회원님께서 글에 좋아요를 눌러주셨습니다
           </p>
         </div>

--- a/src/components/notification/Notification.tsx
+++ b/src/components/notification/Notification.tsx
@@ -1,3 +1,5 @@
+Notification;
+
 import ButtonComponent from "../ButtonComponent";
 import likeIcon from "../../assets/noti_like_Icon.svg";
 import followIcon from "../../assets/noti_follow_Icon.svg";
@@ -6,6 +8,7 @@ import NotificationBox from "../NotificationBox";
 import { api } from "../../api/axios";
 import { AxiosError } from "axios";
 import { useEffect, useState } from "react";
+import { useAuth } from "../../stores/authStore";
 
 interface notificationProps {
   closeNoti: () => void;
@@ -22,8 +25,22 @@ export default function Notification({
   // 모두읽음처리
   const notificationSeen = async () => {
     try {
-      const { status, data } = await api.put("/notifications/seen");
-      showNotiListHandler();
+      // 전역 상태 업데이트
+      setUser({
+        ...userInfo,
+        notifications: userInfo?.notifications?.splice(
+          0,
+          userInfo?.notifications?.length
+        ),
+      });
+      const { status } = await api.put("/notifications/seen");
+      try {
+        setUser(userInfo);
+      } catch (error) {
+        if (status === 400) console.log(error);
+      }
+
+      // showNotiListHandler();
       notificationNumberClean();
     } catch (error) {
       console.log(error);
@@ -32,6 +49,9 @@ export default function Notification({
       }
     }
   };
+
+  const userInfo = useAuth((state) => state.user);
+  const setUser = useAuth((state) => state.setUser);
 
   const notificationNumberClean = () => {
     setNotificationNumber([0, 0, 0]);
@@ -80,7 +100,7 @@ export default function Notification({
         {/* Todo 말풍선 꼬리 tailwind로 만드는법 알아보자 */}
         {/* 말풍선 본문 */}
         <div
-          className="w-[390px] max-h-[560px] overflow-y-scroll bg-white border border-gray-200 rounded-xl shadow-lg p-6 scrollbar-none"
+          className="w-[320px] max-h-[560px] overflow-y-scroll bg-white border border-gray-200 rounded-xl shadow-lg p-6 scrollbar-none"
           onClick={(e) => e.stopPropagation()}
         >
           <div className="space-y-4 scrollbar-none">
@@ -95,7 +115,7 @@ export default function Notification({
                   }}
                 />
                 {notificationNumber[0] != 0 && (
-                  <div className="w-6 h-6 rounded-[50%] bg-red-500 absolute bottom-0 left-14 text-white text-center text-xs leading-loose">
+                  <div className="w-6 h-6 rounded-[50%] bg-red-500 absolute bottom-0 left-12 text-white text-center z-50 text-xs leading-loose">
                     {notificationNumber[0] >= 100
                       ? `99+`
                       : notificationNumber[0]}
@@ -109,7 +129,7 @@ export default function Notification({
                   }}
                 />
                 {notificationNumber[1] != 0 && (
-                  <div className="w-6 h-6 rounded-[50%] bg-red-500 absolute bottom-0 left-48 text-white text-center z-50 text-xs leading-loose">
+                  <div className="w-6 h-6 rounded-[50%] bg-red-500 absolute bottom-0 left-36 text-white text-center z-50 text-xs leading-loose">
                     {notificationNumber[1] >= 100
                       ? `99+`
                       : notificationNumber[1]}
@@ -123,7 +143,7 @@ export default function Notification({
                   }}
                 />
                 {notificationNumber[2] != 0 && (
-                  <div className="w-6 h-6 rounded-[50%] bg-red-500 absolute bottom-0 right-2.5 text-white justify-center text-center z-50 text-xs leading-loose">
+                  <div className="w-6 h-6 rounded-[50%] bg-red-500 absolute bottom-0 right-1.5 text-white justify-center text-center z-50 text-xs leading-loose">
                     {notificationNumber[2] >= 100
                       ? `99+`
                       : notificationNumber[2]}
@@ -140,7 +160,7 @@ export default function Notification({
                 notificationArray.map((notification: any) => (
                   <NotificationBox
                     fullname={notification.author.fullName}
-                    userid={notification.author.email}
+                    userid={notification.author._id}
                     image={notification.author.image}
                     notificationType={
                       notification.like === null || undefined

--- a/src/components/rootlayout/Header.tsx
+++ b/src/components/rootlayout/Header.tsx
@@ -1,3 +1,5 @@
+Header;
+
 import { useNavigate } from "react-router";
 import notifyIcon from "../../assets/notifyIcon.svg";
 import { twMerge } from "tailwind-merge";
@@ -79,7 +81,7 @@ export default function Header({
   };
 
   const test11 = () => {
-    console.log(userInfo?.notifications);
+    console.log(userInfo);
   };
 
   const logoutHandler = () => {
@@ -135,7 +137,7 @@ export default function Header({
           onClick={() => navigate("/")}
         />
       </div>
-      {/* <button onClick={() => test11()}>sdfsg</button> 테스트용버튼*/}
+      {/* <button onClick={() => test11()}>sdfsg</button> */}
 
       {isLoggedIn ? (
         // 로그인 상태 분기
@@ -146,24 +148,22 @@ export default function Header({
           </div>
           <div className="lg:flex gap-2 hidden buttonComponent">
             <ButtonComponent
-              bgcolor="bg-[#265CAC] hover:bg-[#1e4d8a] dark:bg-mainDark dark:hover:bg-mainTextDark"
+              bgcolor="bg-[#265CAC] dark:bg-mainDark"
               textcolor="text-[white] dark:text-blackDark"
-              border="border-0"
               onClick={logoutHandler}
             >
               {"로그아웃"}
             </ButtonComponent>
             <ButtonComponent
-              bgcolor="bg-white hover:bg-skyDark dark:bg-lightBlackDark dark:hover:bg-darkGreyDark"
-              textcolor="text-[#265CAC] dark:text-mainDark"
-              border="border-[2px] border-[#265CAC] dark:border-mainDark"
+              bgcolor="bg-white dark:bg-skyDark"
+              textcolor="text-[#265CAC] dark:text-blackDark"
               onClick={() => navigate("/posting")}
             >
               {"새글등록"}
             </ButtonComponent>
           </div>
           {/* 알림 */}
-          <div className="w-[48px] h-[48px] flex justify-center items-center mx-[10px] relative notification">
+          <div className="w-[48px] h-[48px]  flex justify-center items-center mx-[10px] relative notification">
             <img
               src={!isDark ? notifyIcon : darkNotifyIcon}
               alt="알림 아이콘"
@@ -218,18 +218,16 @@ export default function Header({
           </div>
 
           <ButtonComponent
-            bgcolor="bg-[#265CAC] hover:bg-[#1e4d8a] dark:bg-mainDark dark:hover:bg-mainTextDark"
+            bgcolor="bg-[#265CAC] dark:bg-mainDark"
             textcolor="text-white dark:text-blackDark"
-            border="border-0"
             onClick={() => navigate("/login")}
           >
             {"로그인"}
           </ButtonComponent>
 
           <ButtonComponent
-            bgcolor="bg-white hover:bg-skyDark dark:bg-lightBlackDark dark:hover:bg-darkGreyDark"
-            textcolor="text-[#265CAC] dark:text-mainDark"
-            border="border-[2px] border-[#265CAC] dark:border-mainDark"
+            bgcolor="bg-white dark:bg-skyDark"
+            textcolor="text-[#265CAC] dark:text-blackDark"
             onClick={() => navigate("/signup")}
           >
             {"가입하기"}


### PR DESCRIPTION
## #️⃣연관된 이슈

#328 

## 📝작업 내용

모두읽기 버튼 클릭시 setUser통해 전역변수 수정 및 알림갯수 동기화처리 
알림창 가로폭 살짝 줄임 
메세지 정중앙에 정렬
프로필사진 클릭시 유져페이지로 링크되는 기능 추가 


## 📸 스크린샷

![image](https://github.com/user-attachments/assets/efcfff42-bf3e-4612-b8cd-ce5860808299)


## 💬리뷰 요구사항(선택)
