### PR TITLE
[FEAT] 알림을 클릭 하면 댓글, 좋아요는 해당 게시글로 팔로우는 해당 유저페이지로 이동

### DIFF
--- a/src/components/NotificationBox.tsx
+++ b/src/components/NotificationBox.tsx
@@ -1,11 +1,16 @@
 import { useNavigate } from "react-router";
 import defaultUserImg from "../assets/defaultUser.svg";
+import { getPostDetail } from "../utils/getPostDetail";
+import { api } from "../api/axios";
+import { channelMapping } from "../constants/channel";
 
 interface NotificationBoxPropsType {
   fullname: string;
   image?: string | null;
   userid: string;
   notificationType: string;
+  postId?: string;
+  follow?: string;
 }
 
 export default function NotificationBox({
@@ -13,20 +18,47 @@ export default function NotificationBox({
   image,
   userid,
   notificationType,
+  postId,
+  follow,
 }: NotificationBoxPropsType) {
   const navigate = useNavigate();
 
+  const handleClick = async () => {
+    if (notificationType === "comment" || notificationType === "like") {
+      if (postId) {
+        console.log(postId);
+        const { data } = await api.get(`/posts/${postId}`);
+        console.log(data);
+        const getChannel = Object.keys(channelMapping).find(
+          (key) => channelMapping[key] === data.channel._id
+        );
+        console.log(getChannel);
+        if (getChannel) {
+          navigate(`/${getChannel}/${postId}`);
+        }
+      } else {
+        return;
+      }
+    }
+
+    if (notificationType === "follow") {
+      navigate(`/user/${userid}`);
+    }
+  };
+
   return (
-    <div className="w-[320px] h-[75px] bg-[#EFEFEF] mb-[5px] flex items-center gap-3 pl-[20px] rounded-[10px] flex-shrink-0 dark:bg-darkGreyDark dark:text-greyDark">
+    <div
+      className="w-[320px] h-[75px] bg-[#EFEFEF] mb-[5px] flex items-center 
+      gap-3 pl-[20px] rounded-[10px] flex-shrink-0 
+      dark:bg-darkGreyDark dark:text-greyDark cursor-pointer"
+      onClick={handleClick}
+    >
       {/* 유저 프로필, 현활 */}
 
       <img
         src={image ? image : defaultUserImg}
         alt="사용자 프로필 사진"
         className="w-[48px] h-[48px] rounded-[50%] shadow-inner cursor-pointer"
-        onClick={() => {
-          navigate(`/user/${userid}`);
-        }}
       />
 
       {notificationType === "follow" && (

--- a/src/components/NotificationBox.tsx
+++ b/src/components/NotificationBox.tsx
@@ -19,20 +19,18 @@ export default function NotificationBox({
   userid,
   notificationType,
   postId,
-  follow,
 }: NotificationBoxPropsType) {
   const navigate = useNavigate();
 
   const handleClick = async () => {
     if (notificationType === "comment" || notificationType === "like") {
       if (postId) {
-        console.log(postId);
         const { data } = await api.get(`/posts/${postId}`);
-        console.log(data);
+
         const getChannel = Object.keys(channelMapping).find(
           (key) => channelMapping[key] === data.channel._id
         );
-        console.log(getChannel);
+
         if (getChannel) {
           navigate(`/${getChannel}/${postId}`);
         }

--- a/src/components/notification/Notification.tsx
+++ b/src/components/notification/Notification.tsx
@@ -19,12 +19,48 @@ interface notificationProps {
   notificationArray?: any;
 }
 
+export interface notificationType {
+  seen: boolean;
+  _id: string;
+  author: {
+    role: string;
+    emailVerified: boolean;
+    banned: boolean;
+    isOnline: boolean;
+    posts: string[];
+    likes: string[];
+    comments: string[];
+    followers: string[];
+    following: string[];
+    notifications: string[];
+    messages: [];
+    _id: string;
+    fullName: string;
+    email: string;
+    password: string;
+    createdAt: string;
+    updatedAt: string;
+    __v: number;
+    username: null;
+    image: string;
+    imagePublicId: string;
+  };
+  user: string;
+  post: string;
+  follow?: string;
+  like: null;
+  createdAt: string;
+  updatedAt: string;
+  __v: number;
+}
+
 // API보고 notificationArray 받아서 처리하자
 export default function Notification({
   closeNoti,
   isNoti,
   notificationArray,
 }: notificationProps) {
+  console.log(notificationArray);
   // 모두읽음처리
   const notificationSeen = async () => {
     try {
@@ -80,7 +116,7 @@ export default function Notification({
       let likeCount = 0;
       let followCount = 0;
       let commentCount = 0;
-      notificationArray.map((notification: any) =>
+      notificationArray.map((notification: notificationType) =>
         notification.like === null || undefined
           ? (likeCount = likeCount + 1)
           : notification.follow != undefined
@@ -91,11 +127,6 @@ export default function Notification({
       setNotificationNumber([commentCount, followCount, likeCount]);
     }
   }, []);
-
-  // 여기에 좋아요, 팔로우, 메세지 갯수 받아서 사용
-  // const [notificationNumber, setNotificationNumber] = useState([0, 0, 0]);
-
-  // console.log({ likeNumber });
 
   const isDark = useDarkModeStore((state) => state.isDark);
 
@@ -165,6 +196,7 @@ export default function Notification({
               {notificationArray.length && showNotiList ? (
                 notificationArray.map((notification: any) => (
                   <NotificationBox
+                    key={notification._id}
                     fullname={notification.author.fullName}
                     userid={notification.author._id}
                     image={notification.author.image}
@@ -175,6 +207,8 @@ export default function Notification({
                         ? "follow"
                         : "comment"
                     }
+                    postId={notification?.post}
+                    follow={notification?.follow}
                   ></NotificationBox>
                 ))
               ) : (


### PR DESCRIPTION
## #️⃣연관된 이슈

> #384 

## 📝작업 내용
알림을 클릭 하면 댓글, 좋아요는 해당 게시글로 팔로우는 해당 유저페이지로 이동 구현했습니다

## 📸 스크린샷

https://github.com/user-attachments/assets/fd268d34-bcc8-4659-bb2b-9c022db4d8b7


