### PR TITLE
[BUG] 검색시 무한스크롤 로딩 제거

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -139,7 +139,7 @@ export default function Home() {
           ref={observerRef}
           className={twMerge(hasNextPage && !isLoading ? "" : "hidden")}
         >
-          <InfinityLoading />
+          {status !== "searching" ? <InfinityLoading /> : null}
         </div>
       </div>
     </div>

--- a/src/pages/ReviewPost.tsx
+++ b/src/pages/ReviewPost.tsx
@@ -11,7 +11,7 @@ import InfinityLoading from "../components/InfinityLoading";
 import { twMerge } from "tailwind-merge";
 
 // 무한스크롤에서 몇개씩 보여줄지 선택
-const limit = 5;
+const limit = 12;
 
 export default function ReviewPost() {
   // 로딩 관리
@@ -126,7 +126,7 @@ export default function ReviewPost() {
         ref={observerRef}
         className={twMerge(hasNextPage && !isLoading ? "" : "hidden")}
       >
-        <InfinityLoading />
+        {status !== "searching" ? <InfinityLoading /> : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈
#403 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
검색시 무한스크롤 로딩 제거

현재 검색이 필터링으로 구현되어있어서 검색 상태일 땐 로딩 제거했습니다

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📸 스크린샷

## 💬리뷰 요구사항(선택)
