### PR TITLE
[BUG] 마이페이지 하트 아이콘 상태 반영 안 됨 #430

### DIFF
--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -22,7 +22,7 @@ export default function ImageCard({
   disableNavigate = false,
 }: PostType & MyInfo & { disableNavigate?: boolean }) {
   const { pathname } = useLocation();
-  console.log(disableNavigate, "확인");
+  // console.log(disableNavigate, "확인");
 
   const isLogin = useAuth((state) => state.isLoggedIn);
   const myInfo = useAuth((state) => state.user);

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -20,7 +20,7 @@ export default function UserProfile({
   disableNavigate,
 }: userProfileType) {
   const imgRef = useRef<HTMLInputElement>(null);
-  console.log("2차확인", disableNavigate);
+  // console.log("2차확인", disableNavigate);
   // 로딩중
   const startLoading = useLoadingStore((state) => state.startLoading);
   const stopLoading = useLoadingStore((state) => state.stopLoading);

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -13,7 +13,6 @@ export default function MyPage() {
   const isToggle = usesidebarToggleStore((state) => state.isToggle);
 
   const myInfo = useAuth((state) => state.user);
-
   const isLoading = useLoadingStore((state) => state.isLoading);
 
   const [myLike, setMyLike] = useState<(string | null)[]>([]);
@@ -25,7 +24,7 @@ export default function MyPage() {
       );
       setMyLike(myLike);
     }
-  }, []);
+  }, [myInfo]);
   return (
     <>
       {myInfo && (


### PR DESCRIPTION
## #️⃣연관된 이슈
#430 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
문제
좋아요 상태가 변경되어도 `myLike`가 업데이트되지 않는 문제가 있었습니다.

해결
- `useEffect`의 의존성 배열에 `myInfo`를 추가했습니다.
  - `myInfo`가 업데이트될 때 `myLike`가 최신 상태로 유지되도록 설정했습니다.

결과
이를 통해 사용자가 좋아요(하트) 상태를 변경하면 즉시 UI에 반영됩니다.


> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/50654e1d-8bb2-4f14-9601-f811059fdb0e)
![image](https://github.com/user-attachments/assets/e278d92b-9b4a-461a-ad73-43f5f4a2a12a)

## 💬리뷰 요구사항(선택)
