### PR TITLE
[FIX] 삭제모달 색 변경, 게시글 작성 게시판 식단공유 변경

### DIFF
--- a/src/components/modal/ConfirmModal.tsx
+++ b/src/components/modal/ConfirmModal.tsx
@@ -38,7 +38,7 @@ export default function ConfirmModal({
             <button
               onClick={onConfirm}
               className={twMerge(
-                "w-[100px] h-[38px] rounded text-white dark:text-blackDark dark:font-bold",
+                "w-[100px] h-[38px] rounded text-white dark:text-blackDark dark:font-bold dark:bg-[#F95896]",
                 confirmColor
               )}
             >

--- a/src/pages/Posting.tsx
+++ b/src/pages/Posting.tsx
@@ -52,7 +52,7 @@ export default function Posting() {
   const channels = [
     { id: "675a2e0d0d335f0ddae3a194", name: "오운완 인증", route: "/records" },
     { id: "675a2dac0d335f0ddae3a188", name: "프로틴 추천", route: "/protein" },
-    { id: "675a2dc40d335f0ddae3a18c", name: "루틴 공유", route: "/routine" },
+    { id: "675a2dc40d335f0ddae3a18c", name: "식단 공유", route: "/routine" },
     {
       id: "675a2ddc0d335f0ddae3a190",
       name: "헬스장 리뷰",


### PR DESCRIPTION
## #️⃣연관된 이슈

> #457 

## 📝작업 내용

밥먹기 전에 분명히 검색하면 결과가 두 번씩 나왔는데.. 밥먹고 오니까 갑자기 정상적으로 작동하네용.. pull 받은 것도 없는데 ㅠㅠ

이슈와 다르게 삭제모달의 다크모드 색상 변경요청 들어와서 변경했습니다.
게시글 작성 게사판 루틴 공유 -> 식단 공유로 변경했습니다.

## 📸 스크린샷
<img width="339" alt="스크린샷 2024-12-23 오후 10 00 12" src="https://github.com/user-attachments/assets/c4b96c96-5202-4b9c-8be0-21e9f9e2e39c" />

<img width="463" alt="스크린샷 2024-12-23 오후 10 00 26" src="https://github.com/user-attachments/assets/b1fd1f84-0b5f-4607-bfd1-60643994134b" />
